### PR TITLE
Do not show upstream ME version as disabled if the user has chosen to enable it

### DIFF
--- a/system76driver/firmware.py
+++ b/system76driver/firmware.py
@@ -616,7 +616,7 @@ def get_data(model, model_data, is_notification):
     }
 
     for entry in changelog:
-        if entry.get("bios_me") or entry.get("me_hap") or entry.get("me_cr"):
+        if (entry.get("bios_me") and not get_me_enabled()) or entry.get("me_hap") or entry.get("me_cr"):
             entry["me"] = "disabled"
         for component in latest.keys():
             if component in entry and not latest[component]:


### PR DESCRIPTION
If the ME switch is available, the ME must be disabled to set the changelog entry to "disabled"

This should fix spurious firmware update notifications