### PR TITLE
Update journalctl to provide only the last day of logs

### DIFF
--- a/system76driver/util.py
+++ b/system76driver/util.py
@@ -50,7 +50,7 @@ def dump_logs(base):
     SubProcess.check_call(['dmesg'], stdout=fp)
 
     fp = open(path.join(base, 'journalctl'), 'xb')
-    SubProcess.check_call(['journalctl'], stdout=fp)
+    SubProcess.check_call(['journalctl', '--since', 'yesterday'], stdout=fp)
 
     for parts in [('Xorg.0.log',), ('syslog',)]:  #, ('apt', 'history.log')]:
         src = path.join('/var/log', *parts)


### PR DESCRIPTION
Without limiting journalctl to a timeframe, I have received a 650MB journalctl output, which is a bit unwieldy.