### PR TITLE
Don't split() on a list, fix #52

### DIFF
--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -403,7 +403,7 @@ class GrubAction(Action):
     def get_isneeded(self):
         if self.mode == 'kernelstub':
             current = self.get_current_kernel_options()
-            params = set(current.split())
+            params = set(current)
         elif self.has_cmdline_default():
             current = self.get_current_cmdline()
             params = set(current.split())


### PR DESCRIPTION
Split function does not need to be called here, and causes the error #52 .

I wasn't sure if I should remove the `split()` from line 409. `get_current_cmdline` seems different enough, I figure we can make that change if another regression is reported. 