### PR TITLE
A workaround for the Oryx 4-b backlight control issue

### DIFF
--- a/system76driver/daemon.py
+++ b/system76driver/daemon.py
@@ -618,6 +618,8 @@ def hash_list(list = [], *args):
 
 def apply_dpcd_pwm_fix(model):
     dpcd_pwm = DpcdPwm(model)
+    # Wait for display-manager to start, then
+    # initialize backlight mode.
     while True:
         time.sleep(1)
         output = subprocess.getoutput("systemctl is-active display-manager")
@@ -625,6 +627,9 @@ def apply_dpcd_pwm_fix(model):
             log.info("applying dpcd pwm fix")
             dpcd_pwm.run()
             break
+    # When the computer sleeps or the screen turns off, the
+    # backlight mode often resets. We'll check for this and fix
+    # it if it happens.
     while True:
         time.sleep(2)
         if (dpcd_pwm.is_set () == False):

--- a/system76driver/daemon.py
+++ b/system76driver/daemon.py
@@ -625,19 +625,11 @@ def apply_dpcd_pwm_fix(model):
             log.info("applying dpcd pwm fix")
             dpcd_pwm.run()
             break
-    chash = hash_list(login.sessions())
     while True:
-        time.sleep(1)
-        nhash = hash_list(login.sessions())
-        if nhash != chash:
-            chash = nhash
-            slept = 0
-            while slept < 60:
-                time.sleep(3)
-                slept += 3
-                if (dpcd_pwm.is_set () == False):
-                    log.info('Switching DPCD backlight to PWM %r', model)
-                    dpcd_pwm.run()
+        time.sleep(2)
+        if (dpcd_pwm.is_set () == False):
+            log.info('Switching DPCD backlight to PWM %r', model)
+            dpcd_pwm.run()
 
 def run_dpcd_pwm(model):
     try:


### PR DESCRIPTION
This is a hacky fix for the issue #59, where the Oryx 4-b backlight will snap to full brightness and no longer respond to UI controls after resuming from sleep.

Some kind of backlight mode must be set for the brightness settings to work, but this mode resets itself when the computer sleeps, turns off the screen, and perhaps at other times too.

This fix endlessly checks to see if the mode is set as it  needs to be, and fixes it whenever it isn't.

The sleep interval (2 seconds) is chosen to be slower than the one it replaces, in the hope that there will be no performance or battery regression because of it.

A better fix would prevent the mode reset in the first place, but I don't know how to do that.
