### PR TITLE
Version tag in .desktop file refers to version of Desktop Entry spec

### DIFF
--- a/system76-driver.desktop
+++ b/system76-driver.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=2.7.3
+Version=1.1
 Encoding=UTF-8
 Name=System76 Driver
 GenericName=System76 Driver


### PR DESCRIPTION
I assume 2.7.3 was the system76-driver application version, but the
Version tag in .desktop files is actually supposed to refer to the
version of the Desktop Entry specification being used, to make backwards
compatibility support easier. Sort of like how XML files specify which
XML version they're using at the beginning of every document.

The Version entry key is described here:
<https://specifications.freedesktop.org/desktop-entry-spec/1.1/ar01s05.html>

The highest version of the Desktop Entry spec is 1.2alpha, but since
it's "alpha" I decided to go with the previous release, 1.1. Not that
there have been many significant changes at all so far since 1.0.