### PR TITLE
thelio-major-b2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -34,6 +34,7 @@ Depends: ${python3:Depends}, ${misc:Depends},
     system76-dkms,
     system76-firmware-daemon,
     system76-io-dkms,
+    system76-r8125-dkms,
     system76-power,
     system76-wallpapers,
     xbacklight

--- a/debian/control
+++ b/debian/control
@@ -34,8 +34,8 @@ Depends: ${python3:Depends}, ${misc:Depends},
     system76-dkms,
     system76-firmware-daemon,
     system76-io-dkms,
-    system76-r8125-dkms,
     system76-power,
+    system76-r8125-dkms,
     system76-wallpapers,
     xbacklight
 Recommends: hidpi-daemon


### PR DESCRIPTION
This adds a dependency on the r8125 dkms driver to support the 2.5G ethernet jack on thelio-major-b2