### PR TITLE
Blacklist i2c-nvidia-gpu on oryp5

### DIFF
--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -1289,3 +1289,10 @@ class hda_probe_mask(GrubAction):
 
     def describe(self):
         return _('Fixes for probing Intel HDA device')
+
+class blacklist_nvidia_i2c(FileAction):
+    relpath = ('etc', 'modprobe.d', 'system76-driver_i2c-nvidia-gpu.conf')
+    content = 'blacklist i2c_nvidia_gpu'
+
+    def describe(self):
+        return _('Workaround for delay when loading NVIDIA i2c kernel module')

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -545,6 +545,7 @@ PRODUCTS = {
         'name': 'Oryx Pro',
         'drivers': [
             actions.hda_probe_mask,
+            actions.blacklist_nvidia_i2c,
         ],
     },
 


### PR DESCRIPTION
Yet another place that needs a fix for pop-os/system76-power#71

It turns out that this module needs to be disabled universally, as it causes hangs even in NVIDIA mode