### PR TITLE
Update bump-version.py to not require bzr

### DIFF
--- a/bump-version.py
+++ b/bump-version.py
@@ -95,7 +95,9 @@ def bump_version(current):
 
 
 def build_author_line():
-    author = check_output(['bzr', 'whoami']).decode().strip()
+    user = check_output(['git', 'config', '--get', 'user.name']).decode().strip()
+    email = check_output(['git', 'config', '--get', 'user.email']).decode().strip()
+    author = ' '.join((user, email))
     ts = time.strftime('%a, %d %b %Y %H:%M:%S %z', time.localtime())
     return ' -- {}  {}\n'.format(author, ts)
 


### PR DESCRIPTION
There's no reason one should need bazaar setup to run bump-version.py which uses git.