### PR TITLE
Depend on system76-oled for brightness support on addw1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 system76-driver (19.04.10~~alpha) disco; urgency=low
 
   * Daily WIP for 19.04.10
+  * Depend on system76-oled for brightness support on addw1
 
  -- Jeremy Soller <jeremy@system76.com>  Wed, 17 Jul 2019 14:07:39 -0600
 

--- a/debian/control
+++ b/debian/control
@@ -34,6 +34,7 @@ Depends: ${python3:Depends}, ${misc:Depends},
     system76-dkms,
     system76-firmware-daemon,
     system76-io-dkms,
+    system76-oled,
     system76-power,
     system76-wallpapers,
     xbacklight


### PR DESCRIPTION
This fixes the brightness on the addw1

The new daemon can be seen here: https://github.com/pop-os/system76-oled

When a new ISO is built, system76-oled will need to be added to the pool