### PR TITLE
 Enable NVIDIA modesetting to remove screen tearing on Optimus systems 

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 system76-driver (19.04.11~~alpha) disco; urgency=low
 
   * Daily WIP for 19.04.11
+  * Enable NVIDIA modesetting to remove screen tearing on Optimus systems
 
  -- Jeremy Soller <jeremy@system76.com>  Fri, 26 Jul 2019 08:02:59 -0600
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (19.04.11~~alpha) disco; urgency=low
+
+  * Daily WIP for 19.04.11
+
+ -- Jeremy Soller <jeremy@system76.com>  Fri, 26 Jul 2019 08:02:59 -0600
+
 system76-driver (19.04.10) disco; urgency=low
 
   * Improve instructions for firmware updates

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '19.04.10'
+__version__ = '19.04.11'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -1296,3 +1296,13 @@ class blacklist_nvidia_i2c(FileAction):
 
     def describe(self):
         return _('Workaround for delay when loading NVIDIA i2c kernel module')
+
+class nvidia_modeset(GrubAction):
+    """
+    Add `nvidia_drm.modeset=1` to Linux command line.
+    """
+
+    add = ('nvidia_drm.modeset=1',)
+
+    def describe(self):
+        return _('Enable NVIDIA modesetting to remove screen tearing on Optimus systems')

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -28,7 +28,9 @@ PRODUCTS = {
     # Adder
     'addw1': {
         'name': 'Adder WS',
-        'drivers': [],
+        'drivers': [
+            actions.nvidia_modeset,
+        ],
     },
 
     # Bonobo:
@@ -264,7 +266,9 @@ PRODUCTS = {
     },
     'gaze14': {
         'name': 'Gazelle Pro',
-        'drivers': [],
+        'drivers': [
+            actions.nvidia_modeset,
+        ],
     },
     'gazu1': {
         'name': 'Gazelle Ultra',
@@ -542,6 +546,7 @@ PRODUCTS = {
         'drivers': [
             actions.hidpi_scaling,
             actions.limit_tdp,
+            actions.nvidia_modeset,
         ],
     },
     'oryp4-b': {
@@ -549,6 +554,7 @@ PRODUCTS = {
         'drivers': [
             actions.hidpi_scaling,
             actions.remove_switch_internal_speakers,
+            actions.nvidia_modeset,
         ],
     },
     'oryp5': {
@@ -556,6 +562,7 @@ PRODUCTS = {
         'drivers': [
             actions.hda_probe_mask,
             actions.blacklist_nvidia_i2c,
+            actions.nvidia_modeset,
         ],
     },
 


### PR DESCRIPTION
This should be merged alongside https://github.com/pop-os/nvidia-graphics-drivers/pull/14