### PR TITLE
check if ec_sys file interface already exists before modprobe

### DIFF
--- a/system76driver/daemon.py
+++ b/system76driver/daemon.py
@@ -187,8 +187,11 @@ def save_json_conf(filename, obj):
 
 
 def open_ec(sysdir='/sys'):
-    SubProcess.check_call(['modprobe', 'ec_sys', 'write_support'])
     name = path.join(sysdir, 'kernel', 'debug', 'ec', 'ec0', 'io')
+    if not os.path.exists(name):
+        SubProcess.check_call(['modprobe', 'ec_sys', 'write_support'])
+    if not os.access(name, os.W_OK):
+        log.exception("'%s' is not writable. Maybe kernel cmdline needs 'ec_sys.write_support=1'?")
     fp = open(name, 'rb+', 0)
     return fp
 


### PR DESCRIPTION
The stock Arch Linux kernel has the 'ec_sys' module compiled in, which
means there is nothing to modprobe, causing an error. Make the code
check for the existence of this file interface before attempting to
modprobe.

Also, add a write check as the file interface is not writable by
default.