### PR TITLE
 Blacklist i2c_nvidia_gpu on gaze14 

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (19.04.13~~alpha) disco; urgency=low
+
+  * Daily WIP for 19.04.13
+
+ -- Jeremy Soller <jeremy@system76.com>  Thu, 08 Aug 2019 10:07:45 -0600
+
 system76-driver (19.04.12) disco; urgency=low
 
   * Blacklist i2c_nvidia_gpu on addw1

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 system76-driver (19.04.13~~alpha) disco; urgency=low
 
   * Daily WIP for 19.04.13
+  * Blacklist i2c_nvidia_gpu on gaze14
 
  -- Jeremy Soller <jeremy@system76.com>  Thu, 08 Aug 2019 10:07:45 -0600
 

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '19.04.12'
+__version__ = '19.04.13'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -266,7 +266,9 @@ PRODUCTS = {
     },
     'gaze14': {
         'name': 'Gazelle Pro',
-        'drivers': [],
+        'drivers': [
+            actions.blacklist_nvidia_i2c,
+        ],
     },
     'gazu1': {
         'name': 'Gazelle Ultra',


### PR DESCRIPTION
This also needs to be done on the gaze14 to avoid boot delays on 18.04