### PR TITLE
APT preferences

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (19.04.14~~alpha) disco; urgency=low
+
+  * Daily WIP for 19.04.14
+
+ -- Jeremy Soller <jeremy@system76.com>  Thu, 08 Aug 2019 13:14:45 -0600
+
 system76-driver (19.04.13) disco; urgency=low
 
   * Blacklist i2c_nvidia_gpu on gaze14

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 system76-driver (19.04.14~~alpha) disco; urgency=low
 
   * Daily WIP for 19.04.14
+  * Add APT preferences to prevent overriding
 
  -- Jeremy Soller <jeremy@system76.com>  Thu, 08 Aug 2019 13:14:45 -0600
 

--- a/debian/rules
+++ b/debian/rules
@@ -29,3 +29,7 @@ override_dh_auto_install:
 
 override_dh_installgsettings:
 	dh_installgsettings --priority=40
+
+override_dh_installdeb:
+        dh_installdeb
+        cp debian/conffiles debian/system76-driver/DEBIAN/conffiles

--- a/debian/rules
+++ b/debian/rules
@@ -31,5 +31,5 @@ override_dh_installgsettings:
 	dh_installgsettings --priority=40
 
 override_dh_installdeb:
-        dh_installdeb
-        cp debian/conffiles debian/system76-driver/DEBIAN/conffiles
+	dh_installdeb
+	cp debian/conffiles debian/system76-driver/DEBIAN/conffiles

--- a/debian/system76-driver.install
+++ b/debian/system76-driver.install
@@ -2,6 +2,7 @@ com.system76.pkexec.system76-driver.policy usr/share/polkit-1/actions/
 com.system76.pkexec.system76-firmware.policy usr/share/polkit-1/actions/
 system76-firmware.desktop usr/share/applications/
 system76-nm-restart /lib/systemd/system-sleep/
+system76-apt-preferences /etc/apt/preferences.d/
 system76-third-party-mirrors.cfg /etc/update-manager/release-upgrades.d/
 system76-driver-pkexec usr/bin/
 system76-firmware usr/bin/

--- a/system76-apt-preferences
+++ b/system76-apt-preferences
@@ -1,0 +1,7 @@
+Package: *
+Pin: release o=LP-PPA-system76-dev-stable
+Pin-Priority: 1001
+
+Package: *
+Pin: release o=LP-PPA-system76-dev-pre-stable
+Pin-Priority: 1001

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '19.04.13'
+__version__ = '19.04.14'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)


### PR DESCRIPTION
This will, similar to the Pop APT preferences, prevent overriding packages from the system76-dev PPAs. This must be merged after https://github.com/pop-os/nvidia-graphics-drivers/pull/21 is released and the custom kernels are removed