### PR TITLE
Update make-release script to not rely on bzr

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,8 @@
-system76-driver (19.04.16~~alpha) disco; urgency=low
+system76-driver (19.04.16) disco; urgency=low
 
-  * Daily WIP for 19.04.16
   * Update make-release script to not rely on bzr
 
- -- shpurk <benpack101@gmail.com>  Fri, 23 Aug 2019 18:07:40 -0600
+ -- shpurk <benpack101@gmail.com>  Fri, 23 Aug 2019 18:32:10 -0600
 
 system76-driver (19.04.15) disco; urgency=low
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 system76-driver (19.04.16~~alpha) disco; urgency=low
 
   * Daily WIP for 19.04.16
+  * Update make-release script to not rely on bzr
 
  -- shpurk <benpack101@gmail.com>  Fri, 23 Aug 2019 18:07:40 -0600
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (19.04.16~~alpha) disco; urgency=low
+
+  * Daily WIP for 19.04.16
+
+ -- shpurk <benpack101@gmail.com>  Fri, 23 Aug 2019 18:07:40 -0600
+
 system76-driver (19.04.15) disco; urgency=low
 
   * Remove firmware GUI, now handled by firmware-manager

--- a/make-release.py
+++ b/make-release.py
@@ -127,7 +127,9 @@ def build_version_line(line):
 
 
 def build_author_line():
-    author = check_output(['bzr', 'whoami']).decode().strip()
+    user = check_output(['git', 'config', '--get', 'user.name']).decode().strip()
+    email = check_output(['git', 'config', '--get', 'user.email']).decode().strip()
+    author = ' '.join((user, '<' + email + '>'))
     ts = time.strftime('%a, %d %b %Y %H:%M:%S %z', time.localtime())
     return ' -- {}  {}\n'.format(author, ts)
 

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '19.04.15'
+__version__ = '19.04.16'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)


### PR DESCRIPTION
Identical to the change made to the bump-release script, eliminating the reliance on bzr for releasing a new version of the system76-driver.