### PR TITLE
Reload thunderbolt driver to avoid hangs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 system76-driver (19.04.20~~alpha) disco; urgency=low
 
   * Daily WIP for 19.04.20
+  * system76-thunderbolt-reload: reload thunderbolt device to avoid hangs
 
  -- Jeremy Soller <jeremy@system76.com>  Sun, 27 Oct 2019 18:58:54 -0600
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (19.04.20~~alpha) disco; urgency=low
+
+  * Daily WIP for 19.04.20
+
+ -- Jeremy Soller <jeremy@system76.com>  Sun, 27 Oct 2019 18:58:54 -0600
+
 system76-driver (19.04.19) disco; urgency=low
 
   * Depend on system76-acpi-dkms

--- a/debian/system76-driver.install
+++ b/debian/system76-driver.install
@@ -1,5 +1,6 @@
 com.system76.pkexec.system76-driver.policy usr/share/polkit-1/actions/
 system76-nm-restart /lib/systemd/system-sleep/
+system76-thunderbolt-reload /lib/systemd/system-sleep/
 system76-apt-preferences /etc/apt/preferences.d/
 system76-third-party-mirrors.cfg /etc/update-manager/release-upgrades.d/
 system76-driver-pkexec usr/bin/

--- a/system76-thunderbolt-reload
+++ b/system76-thunderbolt-reload
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# system76-driver: Universal driver for System76 computers
+# Copyright (C) 2005-2019 System76, Inc.
+#
+# This file is part of `system76-driver`.
+#
+# `system76-driver` is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# `system76-driver` is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with `system76-driver`; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# This script removes the thunderbolt PCI bridge on suspend and rescans it
+# on resume in order to prevent hangs on resume.
+
+set -e
+
+case "$(cat /sys/class/dmi/id/product_version)" in
+    darp6 | galp4)
+        case "$2" in
+            suspend | hybrid-sleep)
+                case "$1" in
+                    pre)
+                        echo 1 > '/sys/devices/pci0000:00/0000:00:1c.0/remove'
+                        ;;
+                    post)
+                        echo 1 > '/sys/devices/pci0000:00/0000:00:00.0/rescan'
+                        ;;
+                esac
+                ;;
+        esac
+        ;;
+esac

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '19.04.19'
+__version__ = '19.04.20'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)


### PR DESCRIPTION
This is a workaround that will, on the darp6 and galp4, reload the thunderbolt driver on suspend and resume.