### PR TITLE
actions: Fix string comparison involving newline

### DIFF
--- a/bump-version.py
+++ b/bump-version.py
@@ -71,7 +71,7 @@ def parse_version_line(line):
     if ALPHA in line:
         raise ValueError('{!r} in current version:\n{!r}'.format(ALPHA, line))
     m = re.match(
-        '^system76-driver \(([\.0-9]+)\) ([a-z]+); urgency=low$', line
+        '^system76-driver \(([\.0-9]+)\) ([a-z]+); urgency=(low|medium|high|emergency|critical)$', line
     )
     if m is None:
         raise ValueError('bad version line[0]:\n{!r}'.format(line))

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 system76-driver (20.04.2~~alpha) focal; urgency=low
 
   * Daily WIP for 20.04.2
+  * Fix test for USB audio S/PDIF
 
  -- Tim Crawford <tcrawford@system76.com>  Thu, 12 Mar 2020 12:03:35 -0600
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (20.04.2~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.2
+
+ -- Tim Crawford <tcrawford@system76.com>  Thu, 12 Mar 2020 12:03:35 -0600
+
 system76-driver (20.04.1) focal; urgency=medium
 
   * Update the bump and make file versions to include focal

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.1'
+__version__ = '20.04.2'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -1338,7 +1338,7 @@ class usb_audio_load_spdif(Action):
     def __init__(self, etcdir='/etc'):
         self.filename = path.join(etcdir, 'pulse', 'default.pa')
 
-        sink = '''load-module module-alsa-sink device=hw:CARD=Audio,DEV={} sink_properties="device.description='S/PDIF'"\n'''
+        sink = 'load-module module-alsa-sink device=hw:CARD=Audio,DEV={} sink_properties="device.description=\'S/PDIF\'"'
         if determine_model_new() == 'thelio-major-r2':
             self.value = sink.format('3')
         else:

--- a/system76driver/tests/test_gtk.py
+++ b/system76driver/tests/test_gtk.py
@@ -22,7 +22,7 @@ Unit tests for `system76driver.gtk` module.
 """
 
 from unittest import TestCase
-import platform
+import distro
 from collections import namedtuple
 
 from gi.repository import Gtk
@@ -60,7 +60,7 @@ class TestUI(TestCase):
         )
         self.assertEqual(
             ui.builder.get_object('ubuntuVersion').get_text(),
-            '{} {} ({})'.format(*platform.dist())
+            '{} {} ({})'.format(*distro.linux_distribution())
         )
         self.assertEqual(
             ui.builder.get_object('driverVersion').get_text(),
@@ -82,7 +82,7 @@ class TestUI(TestCase):
         self.assertEqual(ui.builder.get_object('sysModel').get_text(), model)
         self.assertEqual(
             ui.builder.get_object('ubuntuVersion').get_text(),
-            '{} {} ({})'.format(*platform.dist())
+            '{} {} ({})'.format(*distro.linux_distribution())
         )
         self.assertEqual(
             ui.builder.get_object('driverVersion').get_text(),


### PR DESCRIPTION
`splitlines()` strips the line endings, causing `get_isneeded()` to always return true. This caused the setting to always be appended to the PulseAudio config file when system76driver was run.

Fixes: 345cd929d042f ("Load USB audio S/PDIF output device")