### PR TITLE
Focal support

### DIFF
--- a/bump-version.py
+++ b/bump-version.py
@@ -34,7 +34,7 @@ from system76driver import __version__
 from system76driver.tests.helpers import TempDir
 
 
-DISTROS = ('trusty', 'xenial', 'yakkety', 'zesty', 'artful', 'bionic', 'cosmic', 'disco', 'eoan')
+DISTROS = ('trusty', 'xenial', 'yakkety', 'zesty', 'artful', 'bionic', 'cosmic', 'disco', 'eoan', 'focal')
 ALPHA = '~~alpha'
 
 TREE = path.dirname(path.abspath(__file__))

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-system76-driver (20.04ubuntu1) UNRELEASED; urgency=medium
+system76-driver (20.04.1) focal; urgency=medium
 
   * Update the bump and make file versions to include focal
   * Replace platform with disto

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+system76-driver (20.04ubuntu1) UNRELEASED; urgency=medium
+
+  * Update the bump and make file versions to include focal
+  * Replace platform with disto
+  * Add dh-python and disto to import
+
+ -- Aaron Honeycutt <aaron@system76.com>  Wed, 11 Mar 2020 09:54:33 -0600
+
 system76-driver (19.10.2) eoan; urgency=low
 
   * Fix for Threadripper 3 USB audio SPDIF

--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,7 @@ Priority: extra
 Maintainer: System76, Inc. <dev@system76.com>
 Build-Depends: debhelper (>= 9),
     dh-systemd,
+    dh-python,
     gir1.2-gtk-3.0,
     gir1.2-notify-0.7,
     pyflakes3,
@@ -11,6 +12,7 @@ Build-Depends: debhelper (>= 9),
     python3-dbus,
     python3-evdev,
     python3-gi,
+    python3-distro,
     python3-systemd,
     xbacklight
 Standards-Version: 3.9.6
@@ -31,6 +33,7 @@ Depends: ${python3:Depends}, ${misc:Depends},
     python3-dbus,
     python3-evdev,
     python3-gi,
+    python3-distro,
     python3-systemd,
     system76-acpi-dkms,
     system76-dkms,

--- a/make-release.py
+++ b/make-release.py
@@ -34,7 +34,7 @@ from system76driver import __version__
 from system76driver.tests.helpers import TempDir
 
 
-DISTROS = ('trusty', 'xenial', 'yakkety', 'zesty', 'artful', 'bionic', 'cosmic', 'disco', 'eoan')
+DISTROS = ('trusty', 'xenial', 'yakkety', 'zesty', 'artful', 'bionic', 'cosmic', 'disco', 'eoan', 'focal')
 PPA = 'ppa:system76-dev/pre-stable'
 ALPHA = '~~alpha'
 

--- a/system76-driver
+++ b/system76-driver
@@ -24,7 +24,7 @@ import os
 import sys
 import time
 import logging
-import platform
+import distro
 
 import system76driver
 from system76driver.model import determine_model_new
@@ -59,8 +59,8 @@ product = PRODUCTS.get(args.model)
 
 log.info('** Process start at monotonic time %r', time.monotonic())
 log.info('system76driver.__version__: %r', system76driver.__version__)
-log.info('OS: %r', platform.dist())
-log.info('kernel: %r', platform.uname().release)
+log.info('OS: %r', distro.name())
+log.info('kernel: %r', distro.os.uname().release)
 log.info('model: %r', args.model)
 
 ui = UI(args.model, product, args)

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '19.10.2'
+__version__ = '20.04.1'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/gtk.py
+++ b/system76driver/gtk.py
@@ -21,7 +21,7 @@
 Gtk UI.
 """
 
-import platform
+import distro
 import threading
 from gettext import gettext as _
 
@@ -54,7 +54,7 @@ class UI:
         self.details = self.builder.get_object('detailsText')
         self.builder.get_object('sysModel').set_text(model)
         self.builder.get_object('ubuntuVersion').set_text(
-            '{} {} ({})'.format(*platform.dist())
+            '{} {} ({})'.format(*distro.linux_distribution())
         )
         self.builder.get_object('driverVersion').set_text(__version__)
 

--- a/system76driver/util.py
+++ b/system76driver/util.py
@@ -25,7 +25,7 @@ import os
 from os import path
 import shutil
 import tempfile
-import platform
+import distro
 
 from .model import determine_model
 from .mockable import SubProcess
@@ -34,8 +34,8 @@ from .mockable import SubProcess
 def dump_logs(base):
     fp = open(path.join(base, 'systeminfo.txt'), 'x')
     fp.write('System76 Model: {}\n'.format(determine_model()))
-    fp.write('OS Version: {}\n'.format(', '.join(platform.dist())))
-    fp.write('Kernel Version: {}\n'.format(platform.uname().release))
+    fp.write('OS Version: {}\n'.format(', '.join(distro.name())))
+    fp.write('Kernel Version: {}\n'.format(distro.os.uname().release))
 
     fp = open(path.join(base, 'dmidecode'), 'xb')
     SubProcess.check_call(['dmidecode'], stdout=fp)


### PR DESCRIPTION
- Updates platform to distro to fix this issue:
https://github.com/pop-os/system76-driver/pull/137

- Updates the bump-version.py and make-release.py to include focal.

- Updates the debian/control with python3-distro and dh-python.

- Updates the driver version to 20.04.1.