### PR TITLE
Add i8042.nomux to kernel boot parameters on gaze14

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 system76-driver (20.04.11~~alpha) focal; urgency=low
 
   * Daily WIP for 20.04.11
+  * Add i8042.nomux to kernel boot parameters on gaze14 to prevent keyboard issue after suspend/resume
 
  -- Jacob Kauffmann <jacob@system76.com>  Mon, 22 Jun 2020 07:53:12 -0600
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (20.04.11~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.11
+
+ -- Jacob Kauffmann <jacob@system76.com>  Mon, 22 Jun 2020 07:53:12 -0600
+
 system76-driver (20.04.10) focal; urgency=low
 
   * Add oryp6

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.10'
+__version__ = '20.04.11'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -569,6 +569,19 @@ class plymouth1080(Action):
         self.atomic_write(content)
 
 
+class i8042_nomux(GrubAction):
+    """
+    Add i8042.nomux to GRUB_CMDLINE_LINUX_DEFAULT
+
+    This prevents keyboard issues after suspend/resume on gaze14.
+    """
+
+    add = ('i8042.nomux',)
+
+    def describe(self):
+        return _('Fix keyboard after suspend/resume')
+
+
 class i8042_reset_nomux(GrubAction):
     """
     Add i8042.reset and i8042.nomux to GRUB_CMDLINE_LINUX_DEFAULT

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -284,6 +284,7 @@ PRODUCTS = {
         'name': 'Gazelle',
         'drivers': [
             actions.blacklist_nvidia_i2c,
+            actions.i8042_nomux,
         ],
     },
     'gaze15': {


### PR DESCRIPTION
This PR adds a new action for adding i8042.nomux to the kernel boot parameters, and adds that action to the list for gaze14 to apply.

(I went with a new action rather than re-using the oryp2 action because i8042.reset isn't needed for this issue based on testing, and I would have needed to modify the comment and label for the oryp2 touchpad action to be more vague or include multiple items. It seems cleaner to have this as its own action.)

- Installed fresh copy of Pop 20.04
- Added repo, installed updates-- saw the action get applied
- Rebooted, ran `dmesg`, observed `i8042.nomux` was present in kernel boot parameters
- Confirmed keyboard after suspend/resume issue does not occur.