### PR TITLE
Enable WebRender on the serw12

### DIFF
--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -1383,3 +1383,11 @@ class remove_usb_audio_load_spdif(Action):
     def perform(self):
         content = '\n'.join(self.iter_lines())
         self.atomic_write(content)
+
+class firefox_enablewebrender144(FileAction):
+    relpath = ('usr', 'lib', 'firefox', 'defaults', 'pref', 's76-webrender.js')
+    content = 'pref("gfx.webrender.all", true);\n'
+    content += 'pref("layout.frame_rate", 144);\n'
+
+    def describe(self):
+        return _('Enable WebRender in Firefox by default')

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -832,7 +832,9 @@ PRODUCTS = {
     },
     'serw12': {
         'name': 'Serval WS',
-        'drivers': [],
+        'drivers': [
+            actions.firefox_enablewebrender144,
+        ],
     },
 
     # Silverback:


### PR DESCRIPTION
It seems non-optimal to write this to `/usr`, but Firefox doesn't read such configuration from a subdirectory of `/etc`.

The replaces the use of `xrender`, which was enabled by https://github.com/pop-os/default-settings/pull/96.

Note for this to take effect, `xrender` should be disabled.