### PR TITLE
update restart command to systemd usage

### DIFF
--- a/system76-nm-restart
+++ b/system76-nm-restart
@@ -33,7 +33,7 @@ set -e
 if [ "$2" = "suspend" ] || [ "$2" = "hybrid-sleep" ]; then
     case "$1" in
         pre) true ;;
-        post) sleep 1 && service network-manager restart ;;
+        post) sleep 1 && sudo systemctl restart NetworkManager ;;
     esac
 fi
 


### PR DESCRIPTION
The systemd service for NetworkManager was renamed so the old mapping does not work any longer. This updates the command to systemd specs.

service network-manager restart
Failed to restart network-manager.service: Unit network-manager.service not found.
