### PR TITLE
Set card name to 'Audio' for thelio-mega-r1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (20.04.17~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.17
+
+ -- Tim Crawford <tcrawford@system76.com>  Thu, 19 Nov 2020 13:21:44 -0700
+
 system76-driver (20.04.16) focal; urgency=low
 
   * Add galp5, lemp10, pang10, and thelio-mira-r1

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 system76-driver (20.04.17~~alpha) focal; urgency=low
 
   * Daily WIP for 20.04.17
+  * Set card name to 'Audio' for thelio-mega-r1
 
  -- Tim Crawford <tcrawford@system76.com>  Thu, 19 Nov 2020 13:21:44 -0700
 

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.16'
+__version__ = '20.04.17'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/userdaemon.py
+++ b/system76driver/userdaemon.py
@@ -131,7 +131,10 @@ def run_backlight(model):
 class UsbAudio:
     def __init__(self, model, rootdir='/'):
         self.model = model
-        self.name = "ALC1220VBDT"
+        if self.model == "thelio-mega-r1":
+            self.name = "Audio"
+        else:
+            self.name = "ALC1220VBDT"
         self.mic_dev = 1
         if self.model.startswith("thelio-major-r2"):
             self.spdif_dev = 3


### PR DESCRIPTION
Do only the *.1 revisions use ALC1220VBDT as the card name?
Does the major-r2 need its name changed back also?
