### PR TITLE
Symbolic icon on Toolbar

### DIFF
--- a/system76driver/data/gtk3.glade
+++ b/system76driver/data/gtk3.glade
@@ -641,7 +641,7 @@ log file will be available in your home folder.</property>
                   <object class="GtkImage" id="notifyImage">
                     <property name="can_focus">False</property>
                     <property name="xpad">3</property>
-                    <property name="stock">gtk-info</property>
+                    <property name="stock">help-info-symbolic</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>


### PR DESCRIPTION
This PR fix support monochrome icon themes (like as Breeze, Papirus & etc) on Darker GTK Themes (Dark Toolbar & Light Window):
![image](https://user-images.githubusercontent.com/8083855/101130392-d8402a00-361c-11eb-9417-119e896d1a36.png)
