### PR TITLE
serw12: set NVIDIA ForceFullCompositionPipeline (and unset Firefox WebRender)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (20.04.18~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.18
+
+ -- Jacob Kauffmann <jacob@system76.com>  Mon, 14 Dec 2020 11:56:45 -0700
+
 system76-driver (20.04.17) focal; urgency=low
 
   * Set card name to 'Audio' for thelio-mega-r1

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.17'
+__version__ = '20.04.18'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -1414,21 +1414,13 @@ class nvidia_forcefullcompositionpipeline(FileAction):
         return _('Enable ForceFullCompositionPipeline in the NVIDIA driver')
 
     def __init__(self, etcdir='/etc'):
-        self.filename = path.join(etcdir, 'profile')
-
-    def read(self):
-        return open(self.filename, 'r').read()
+        self.filename = path.join(etcdir, 'profile.d', 's76-nvidia-fullcomp.sh')
 
     def get_isneeded(self):
-        if "ForceFullCompositionPipeline" in self.read():
-            return False
-        else:
-            return True
+        return not os.path.exists(self.filename)
 
     def perform(self):
-        content = self.read_and_backup()
-        content += '\n'
-        content += '# Added by system76-driver.\n'
+        content = '# Added by system76-driver.\n'
         content += '# Force a full composition pipeline to prevent stuttering.\n'
         content += 'nvidia-settings --assign CurrentMetaMode="nvidia-auto-select +0+0 { ForceFullCompositionPipeline = On }"\n'
         self.atomic_write(content)

--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -1394,9 +1394,9 @@ class firefox_enablewebrender144(FileAction):
         
 class nvidia_forcefullcompositionpipeline(FileAction):
     relpath = ('etc', 'profile')
-    content = '# Added by system76-driver.\n')
-    content += '# Force a full composition pipeline to prevent stuttering.\n')
-    content += 'nvidia-settings --assign CurrentMetaMode="nvidia-auto-select +0+0 { ForceFullCompositionPipeline = On }"')
+    content = '# Added by system76-driver.\n'
+    content += '# Force a full composition pipeline to prevent stuttering.\n'
+    content += 'nvidia-settings --assign CurrentMetaMode="nvidia-auto-select +0+0 { ForceFullCompositionPipeline = On }"'
     
     def describe(self):
         return _('Enable ForceFullCompositionPipeline in the NVIDIA driver')

--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -1410,6 +1410,9 @@ class firefox_unsetwebrender(FileAction):
             pass
 
 class nvidia_forcefullcompositionpipeline(FileAction):
+    def describe(self):
+        return _('Enable ForceFullCompositionPipeline in the NVIDIA driver')
+
     def __init__(self, etcdir='/etc'):
         self.filename = path.join(etcdir, 'profile')
 
@@ -1429,6 +1432,3 @@ class nvidia_forcefullcompositionpipeline(FileAction):
         content += '# Force a full composition pipeline to prevent stuttering.\n'
         content += 'nvidia-settings --assign CurrentMetaMode="nvidia-auto-select +0+0 { ForceFullCompositionPipeline = On }"\n'
         self.atomic_write(content)
-
-    def describe(self):
-        return _('Enable ForceFullCompositionPipeline in the NVIDIA driver')

--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -1391,3 +1391,12 @@ class firefox_enablewebrender144(FileAction):
 
     def describe(self):
         return _('Enable WebRender in Firefox by default')
+        
+class nvidia_forcefullcompositionpipeline(FileAction):
+    relpath = ('etc', 'profile')
+    content = '# Added by system76-driver.\n')
+    content += '# Force a full composition pipeline to prevent stuttering.\n')
+    content += 'nvidia-settings --assign CurrentMetaMode="nvidia-auto-select +0+0 { ForceFullCompositionPipeline = On }"')
+    
+    def describe(self):
+        return _('Enable ForceFullCompositionPipeline in the NVIDIA driver')

--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -1394,9 +1394,10 @@ class firefox_enablewebrender144(FileAction):
         
 class nvidia_forcefullcompositionpipeline(FileAction):
     relpath = ('etc', 'profile')
-    content = '# Added by system76-driver.\n'
+    content += '\n'
+    content += '# Added by system76-driver.\n'
     content += '# Force a full composition pipeline to prevent stuttering.\n'
-    content += 'nvidia-settings --assign CurrentMetaMode="nvidia-auto-select +0+0 { ForceFullCompositionPipeline = On }"'
+    content += 'nvidia-settings --assign CurrentMetaMode="nvidia-auto-select +0+0 { ForceFullCompositionPipeline = On }"\n'
     
     def describe(self):
         return _('Enable ForceFullCompositionPipeline in the NVIDIA driver')

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -846,6 +846,7 @@ PRODUCTS = {
         'name': 'Serval WS',
         'drivers': [
             actions.firefox_enablewebrender144,
+            actions.nvidia_forcefullcompositionpipeline,
         ],
     },
 

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -845,7 +845,8 @@ PRODUCTS = {
     'serw12': {
         'name': 'Serval WS',
         'drivers': [
-            actions.firefox_enablewebrender144,
+            actions.firefox_framerate144,
+            actions.firefox_unsetwebrender,
             actions.nvidia_forcefullcompositionpipeline,
         ],
     },


### PR DESCRIPTION
This PR will persistently set the NVIDIA driver's `ForceFullCompositionPipeline` option on serw12 by placing a command in `/etc/profile` to enable the option at login. After enabling it this way, it continues to stay enabled when adding, removing, or reconfiguring displays.

Since the `ForceFullCompositionPipeline` not only fixes input lag in LibreOffice/Terminal but also fixes the scroll lag in Firefox's default software renderer, this PR also unsets the WebRender override that was previously being used in order to keep the diff minimal. (We now set only the `frame_rate` option for Firefox, since that is still needed for full performance with the default renderer.)

Tested and confirmed working on lab serw12:
- All config modifications are made as intended.
- Re-configuring `system76-driver` does not duplicate the configurations.
- After the configurations are made and the system is rebooted, Firefox scrolling is smooth and LibreOffice Writer input is not laggy. Performed testing with many windows and applications, did not see any issues caused by the new NVIDIA setting.
  - The screen blinks four times instead of two times when logging in, which seems preferable to the input lag.