### PR TITLE
Add i8042.nomux option to gaze15 and serw12

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (20.04.20~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.20
+
+ -- Jeremy Soller <jeremy@system76.com>  Fri, 18 Dec 2020 12:40:05 -0700
+
 system76-driver (20.04.19) focal; urgency=low
 
   * galp5: Set NVIDIA dynamic power to recommended value

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,9 @@
 system76-driver (20.04.20~~alpha) focal; urgency=low
 
   * Daily WIP for 20.04.20
+  * gaze15 & serw12: Add i8042.nomux option to prevent keyboard issues after suspend.
 
- -- Jeremy Soller <jeremy@system76.com>  Fri, 18 Dec 2020 12:40:05 -0700
+ -- Jacob Kauffmann <jacob@system76.com>  Tue, 15 Dec 2020 11:41:25 -0700
 
 system76-driver (20.04.19) focal; urgency=low
 

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.19'
+__version__ = '20.04.20'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -573,7 +573,7 @@ class i8042_nomux(GrubAction):
     """
     Add i8042.nomux to GRUB_CMDLINE_LINUX_DEFAULT
 
-    This prevents keyboard issues after suspend/resume on gaze14.
+    This prevents keyboard issues after suspend/resume on some products.
     """
 
     add = ('i8042.nomux',)

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -301,6 +301,7 @@ PRODUCTS = {
         'name': 'Gazelle',
         'drivers': [
             actions.blacklist_nvidia_i2c,
+            actions.i8042_nomux,
         ],
     },
     'gazu1': {
@@ -850,6 +851,7 @@ PRODUCTS = {
             actions.firefox_framerate144,
             actions.firefox_unsetwebrender,
             actions.nvidia_forcefullcompositionpipeline,
+            actions.i8042_nomux,
         ],
     },
 


### PR DESCRIPTION
Currently, the gaze15 (NH50DB) keyboard sometimes doesn't work after suspend/resume and requires an additional suspend/resume to bring back (able to recreate after 1-3 suspends.) After this change, it passed 50 suspend/resumes with no keyboard failures.

serw12 was also experiencing the same problem occasionally, and no longer has the issue after applying this action.