### PR TITLE
 galp5: Set NVIDIA dynamic power to recommended value

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 system76-driver (20.04.19~~alpha) focal; urgency=low
 
   * Daily WIP for 20.04.19
+  * galp5: Set NVIDIA dynamic power to recommended value
 
  -- Jeremy Soller <jeremy@system76.com>  Tue, 15 Dec 2020 15:27:08 -0700
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (20.04.19~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.19
+
+ -- Jeremy Soller <jeremy@system76.com>  Tue, 15 Dec 2020 15:27:08 -0700
+
 system76-driver (20.04.18) focal; urgency=low
 
   * serw12: set NVIDIA ForceFullCompositionPipeline (and unset Firefox WebRender)

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.18'
+__version__ = '20.04.19'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -1424,3 +1424,10 @@ class nvidia_forcefullcompositionpipeline(FileAction):
         content += '# Force a full composition pipeline to prevent stuttering.\n'
         content += 'nvidia-settings --assign CurrentMetaMode="nvidia-auto-select +0+0 { ForceFullCompositionPipeline = On }"\n'
         self.atomic_write(content)
+
+class nvidia_dynamic_power_one(FileAction):
+    relpath = ('etc', 'modprobe.d', 'zzz-s76-nvidia-dynpwr.conf')
+    content = 'options nvidia NVreg_DynamicPowerManagement=0x01\n'
+
+    def describe(self):
+        return _('Set NVIDIA dynamic power to recommended value')

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -200,7 +200,9 @@ PRODUCTS = {
     },
     'galp5': {
         'name': 'Galago Pro',
-        'drivers': [],
+        'drivers': [
+            actions.nvidia_dynamic_power_one,
+        ],
     },
 
     # Gazelle:


### PR DESCRIPTION
This works around a driver bug when unplugging the AC adapter while the NVIDIA GPU is off