### PR TITLE
oryp6: Add i915 driver to initramfs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (20.04.21~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.21
+
+ -- Jeremy Soller <jeremy@system76.com>  Mon, 28 Dec 2020 15:44:37 -0700
+
 system76-driver (20.04.20) focal; urgency=low
 
   * gaze15 & serw12: Add i8042.nomux option to prevent keyboard issues after suspend.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 system76-driver (20.04.21~~alpha) focal; urgency=low
 
   * Daily WIP for 20.04.21
+  * oryp6: Add i915 driver to initramfs
 
  -- Jeremy Soller <jeremy@system76.com>  Mon, 28 Dec 2020 15:44:37 -0700
 

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.20'
+__version__ = '20.04.21'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -101,6 +101,11 @@ def update_kernelstub():
     SubProcess.check_call(['kernelstub'])
 
 
+def update_initramfs():
+    log.info('Calling `update-initramfs`...')
+    SubProcess.check_call(['update-initramfs', '-u'])
+
+
 def parse_lspci(text):
     """
     Parse output of `lspci -vmnn`.
@@ -155,6 +160,7 @@ class Action:
     _isneeded = None
     _description = None
     update_grub = False
+    update_initramfs = False
 
     @property
     def isneeded(self):
@@ -256,6 +262,10 @@ class ActionRunner:
             else:
                 yield _('Running `update-grub`')
                 update_grub()
+
+        if any(action.update_initramfs for action in self.needed):
+            yield _('Running `update-initramfs`')
+            update_initramfs()
 
 
 class FileAction(Action):
@@ -1431,3 +1441,11 @@ class nvidia_dynamic_power_one(FileAction):
 
     def describe(self):
         return _('Set NVIDIA dynamic power to recommended value')
+
+class i915_initramfs(FileAction):
+    update_initramfs = True
+    relpath = ('usr', 'share', 'initramfs-tools', 'modules.d', 's76-i915-initramfs.conf')
+    content = '# Added by system76-driver\ni915\n'
+
+    def describe(self):
+        return _('Add i915 driver to initramfs')

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -614,6 +614,7 @@ PRODUCTS = {
         'name': 'Oryx Pro',
         'drivers': [
             actions.blacklist_nvidia_i2c,
+            actions.i915_initramfs,
         ],
     },
 


### PR DESCRIPTION
This ought to fix X crashes on Ubuntu 20.04