### PR TITLE
Add apt/history logs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (20.04.25~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.25
+
+ -- Aaron Honeycutt <aaron@system76.com>  Wed, 20 Jan 2021 11:15:51 -0700
+
 system76-driver (20.04.24) focal; urgency=low
 
   * Set card name to 'Audio' on mega-r1*

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.24'
+__version__ = '20.04.25'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/util.py
+++ b/system76driver/util.py
@@ -64,8 +64,10 @@ def dump_logs(base):
     dump_path(base, "apt/sources.list.d", "/etc/apt/sources.list.d")
     dump_path(base, "syslog", "/var/log/syslog")
     dump_path(base, "Xorg.log", "/var/log/Xorg.0.log")
-
-
+    dump_path(base, "apt/history", "/var/log/apt/history.log")
+    dump_path(base, "apt/history-rotated", "/var/log/apt/history.log.1.gz")
+    dump_path(base, "apt/term", "/var/log/apt/term.log")
+    dump_path(base, "apt/term-rotated", "/var/log/apt/term.log.1.gz")
 
 def create_tmp_logs(func=dump_logs):
     tmp = tempfile.mkdtemp(prefix='logs.')
@@ -82,7 +84,6 @@ def create_tmp_logs(func=dump_logs):
     ]
     SubProcess.check_call(cmd)
     return (tmp, tgz)
-
 
 def create_logs(homedir, func=dump_logs):
     (tmp, src) = create_tmp_logs(func)


### PR DESCRIPTION
This PR adds the following files to the driver which is helpful for support and engineering/QA:

- /var/log/apt/history.log
- /var/log/apt/history.log.1.gz
- /var/log/apt/term.log
- /var/log/apt/term.log.1.gz

Tested on a `galp3-b` and a `lemp9`. One was running Ubuntu 20.04 LTS and the other running Pop 20.10.