### PR TITLE
Move wallpapers to recommends and remove gsettings override

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -41,9 +41,9 @@ Depends: ${python3:Depends}, ${misc:Depends},
     system76-io-dkms,
     system76-oled,
     system76-power,
-    system76-wallpapers,
     xbacklight
-Recommends: hidpi-daemon
+Recommends: hidpi-daemon,
+            system76-wallpapers
 Description: Universal driver for System76 computers
  System76 Driver provides drivers, restore, and regression support for System76
  computers running Ubuntu.  Click the Device Menu (power icon at the top right

--- a/debian/system76-driver.gsettings-override
+++ b/debian/system76-driver.gsettings-override
@@ -9,9 +9,6 @@ display-line-numbers = true
 display-right-margin = true
 highlight-current-line = true
 
-[org.gnome.desktop.background]
-picture-uri = 'file:///usr/share/backgrounds/System76-Fractal_Mountains-by_Kate_Hazen_of_System76.png'
-
 [com.canonical.Unity.Lenses]
 remote-content-search = 'none'
 


### PR DESCRIPTION
The gsettings override will be added to the `system76-wallpapers` package instead. This will allow users to remove the `system76-wallpapers` package (or install the driver with `--no-recommends`) if they don't want it.