### PR TITLE
Remove NVIDIA dynamic power override

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (20.04.26~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.26
+
+ -- Jeremy Soller <jeremy@system76.com>  Mon, 25 Jan 2021 09:31:42 -0700
+
 system76-driver (20.04.25) focal; urgency=low
 
   * Move wallpapers to recommends and remove gsettings override

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 system76-driver (20.04.26~~alpha) focal; urgency=low
 
   * Daily WIP for 20.04.26
+  * Update to NVIDIA driver 460
 
  -- Jeremy Soller <jeremy@system76.com>  Mon, 25 Jan 2021 09:31:42 -0700
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ system76-driver (20.04.26~~alpha) focal; urgency=low
 
   * Daily WIP for 20.04.26
   * Update to NVIDIA driver 460
+  * Remove NVIDIA dynamic power override
 
  -- Jeremy Soller <jeremy@system76.com>  Mon, 25 Jan 2021 09:31:42 -0700
 

--- a/debian/control
+++ b/debian/control
@@ -53,7 +53,7 @@ Description: Universal driver for System76 computers
 Package: system76-driver-nvidia
 Architecture: all
 Depends: ${misc:Depends},
-    nvidia-driver-455,
+    nvidia-driver-460,
     system76-driver (>= ${binary:Version}),
     ubuntu-drivers-common,
 Recommends: amd-ppt-bin

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.25'
+__version__ = '20.04.26'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -1426,7 +1426,7 @@ class nvidia_forcefullcompositionpipeline(FileAction):
     def __init__(self, etcdir='/etc'):
         self.oldfilename = path.join(etcdir, 'profile.d', 's76-nvidia-fullcomp.sh')
         self.filename = path.join(etcdir, 'xprofile')
-    
+
     def read(self):
         return open(self.filename, 'r').read()
 
@@ -1467,12 +1467,20 @@ class nvidia_forcefullcompositionpipeline(FileAction):
         content += 'nvidia-settings --assign CurrentMetaMode="$newmode"\n'
         self.atomic_write(content)
 
-class nvidia_dynamic_power_one(FileAction):
+class remove_nvidia_dynamic_power_one(FileAction):
     relpath = ('etc', 'modprobe.d', 'zzz-s76-nvidia-dynpwr.conf')
-    content = 'options nvidia NVreg_DynamicPowerManagement=0x01\n'
+
+    def get_isneeded(self):
+        return os.path.exists(self.filename)
+
+    def perform(self):
+        try:
+            os.remove(self.filename)
+        except:
+            pass
 
     def describe(self):
-        return _('Set NVIDIA dynamic power to recommended value')
+        return _('Remove NVIDIA dynamic power override')
 
 class i915_initramfs(FileAction):
     update_initramfs = True

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -205,7 +205,7 @@ PRODUCTS = {
     'galp5': {
         'name': 'Galago Pro',
         'drivers': [
-            actions.nvidia_dynamic_power_one,
+            actions.remove_nvidia_dynamic_power_one,
         ],
     },
 


### PR DESCRIPTION
When NVIDIA driver 460 is available, https://github.com/pop-os/nvidia-graphics-drivers/pull/85, this can be merged.