### PR TITLE
Add sensor data

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 system76-driver (20.04.30~~alpha) focal; urgency=low
 
   * Daily WIP for 20.04.30
+  * Add sensors command to log output
+  * Handle cases where commands are missing
 
  -- Aaron Honeycutt <aaronhoneycutt@pm.me>  Tue, 16 Feb 2021 08:58:20 -0700
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (20.04.30~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.30
+
+ -- Aaron Honeycutt <aaronhoneycutt@pm.me>  Tue, 16 Feb 2021 08:58:20 -0700
+
 system76-driver (20.04.29) focal; urgency=low
 
   * Add oryp7

--- a/debian/control
+++ b/debian/control
@@ -43,6 +43,7 @@ Depends: ${python3:Depends}, ${misc:Depends},
     system76-power,
     xbacklight
 Recommends: hidpi-daemon,
+            lm-sensors,
             system76-wallpapers
 Description: Universal driver for System76 computers
  System76 Driver provides drivers, restore, and regression support for System76

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.29'
+__version__ = '20.04.30'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/util.py
+++ b/system76driver/util.py
@@ -26,13 +26,14 @@ from os import path
 import shutil
 import tempfile
 import distro
+import subprocess
 
 from .model import determine_model
-from .mockable import SubProcess
 
 def dump_command(base, name, args):
-    fp = open(path.join(base, name), 'xb')
-    SubProcess.check_call(args, stdout=fp)
+    fp = open(path.join(base, name), 'xt')
+    output = subprocess.run(" ".join(args), capture_output=True, shell=True, text=True)
+    fp.write(output.stdout + "\n" + output.stderr)
 
 def dump_path(base, name, src):
     if path.exists(src):
@@ -59,6 +60,7 @@ def dump_logs(base):
     dump_command(base, "lsblk", ["lsblk", "-f"])
     dump_command(base, "df", ["df", "-h"])
     dump_command(base, "journalctl", ["journalctl", "--since", "yesterday"])
+    dump_command(base, "sensors", ["sensors"])
     dump_path(base, "fstab", "/etc/fstab")
     dump_path(base, "apt/sources.list", "/etc/apt/sources.list")
     dump_path(base, "apt/sources.list.d", "/etc/apt/sources.list.d")
@@ -82,7 +84,7 @@ def create_tmp_logs(func=dump_logs):
         '-C', tmp,
         'system76-logs',
     ]
-    SubProcess.check_call(cmd)
+    subprocess.run(cmd)
     return (tmp, tgz)
 
 def create_logs(homedir, func=dump_logs):


### PR DESCRIPTION
This adds the following to the driver:
- updates debian/control to include `lm-sensors` to the deps 
- adds the sensors command to the dump command section

Tested on Pop 20.10. 