### PR TITLE
Pang10 wd blue

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (20.04.31~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.31
+
+ -- leviport <levi@system76.com>  Mon, 05 Apr 2021 10:47:49 -0600
+
 system76-driver (20.04.30) focal; urgency=low
 
   * Add sensors command to log output

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.30'
+__version__ = '20.04.31'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -604,6 +604,17 @@ class i8042_reset_nomux(GrubAction):
     def describe(self):
         return _('Enable Touchpad')
 
+class pang10_nvme_fix(GrubAction):
+    """
+    Add nvme_core.default_ps_max_latency_us=10000 to GRUB_CMDLINE_LINUX_DEFAULT
+
+    This fixes pang10 crashes with WD Blue NVMe drives.
+    """
+
+    add = ('nvme_core.default_ps_max_latency_us=10000',)
+
+    def describe(self):
+        return _('Change WD Blue drive pstate latency, fixing crashes on pang10')
 
 class gfxpayload_text(Action):
     update_grub = True

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -665,7 +665,9 @@ PRODUCTS = {
     },
     'pang10': {
         'name': 'Pangolin',
-        'drivers': [],
+        'drivers': [
+            actions.pang10_nvme_fix,
+        ],
     },
     #'panv1': {'name': 'Pangolin Value'},  # FIXME: Not in model.py
     'panv2': {


### PR DESCRIPTION
Setting it to 10000 allows Samsung drives to continue to enter PS3 and PS4, but prevents the WD Blue drive from entering these power states. 