### PR TITLE
Add meer6

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 system76-driver (20.04.32~~alpha) focal; urgency=low
 
   * Daily WIP for 20.04.32
+  * Add meer6
 
  -- Jacob Kauffmann <jacob@system76.com>  Wed, 12 May 2021 14:03:45 -0600
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (20.04.32~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.32
+
+ -- Jacob Kauffmann <jacob@system76.com>  Wed, 12 May 2021 14:03:45 -0600
+
 system76-driver (20.04.31) focal; urgency=low
 
   * Add pang10 WD Blue drive fix

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.31'
+__version__ = '20.04.32'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/model.py
+++ b/system76driver/model.py
@@ -192,6 +192,7 @@ TABLES = {
         'meer3': 'meer3',
         'meer4': 'meer4',
         'meer5': 'meer5',
+        'meer6': 'meer6',
         'ment1': 'ment1',
         'ment2': 'ment2',
         'ment3': 'ment3',

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -541,6 +541,12 @@ PRODUCTS = {
             actions.headset_meer5_fixup,
         ],
     },
+    'meer6': {
+        'name': 'Meerkat',
+        'drivers': [
+            actions.hda_disable_power_save,
+        ],
+    },
 
     # Oryx:
     'orxp1': {


### PR DESCRIPTION
Includes applying the `snd_hda_intel.power_save=0` boot option, which gets the HDMI audio working.
  - Without this option, audio only works if I boot with the display set to a different input and switch to HDMI at the cryptsetup prompt; booting normally only shows a dummy output available, with all profiles showing unplugged/unavailable in PulseAudio.
  - This may not be required in the future, as a Fedora 34 live disk doesn't need this boot option, but Pop 21.04 and mainline kernel 5.12.3 don't fix the issue, so it seems to be required for now.