### PR TITLE
Fix meer6 audio

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (20.04.33~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.33
+
+ -- Jacob Kauffmann <jacob@system76.com>  Thu, 13 May 2021 11:20:22 -0600
+
 system76-driver (20.04.32) focal; urgency=low
 
   * Add meer6

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
 system76-driver (20.04.33~~alpha) focal; urgency=low
 
+  * Apply meer6 audio fix
   * Daily WIP for 20.04.33
 
  -- Jacob Kauffmann <jacob@system76.com>  Thu, 13 May 2021 11:20:22 -0600

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.32'
+__version__ = '20.04.33'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -1510,3 +1510,31 @@ class i915_initramfs(FileAction):
 
     def describe(self):
         return _('Add i915 driver to initramfs')
+
+class hda_force_enable_audio(FileAction):
+    def describe(self):
+        return _('Force enable audio via HDMI/DP for Intel HDA')
+
+    def __init__(self, etcdir='/etc'):
+        self.filename = path.join(etcdir, 'xprofile')
+
+    def read(self):
+        return open(self.filename, 'r').read()
+
+    def get_isneeded(self):
+        if not os.path.exists(self.filename):
+            return True
+        elif not "xrandr --output DP-1 --set audio on" in self.read():
+            return True
+        else:
+            return False
+
+    def perform(self):
+        if os.path.exists(self.filename):
+            content = self.read_and_backup()
+            content += '\n# Added by system76-driver.\n'
+        else:
+            content = '# Added by system76-driver.\n'
+        content += '# Force audio output from DP-1 (physical HDMI 1 port.)\n\n'
+        content += 'xrandr --output DP-1 --set audio on'
+        self.atomic_write(content)

--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -1535,6 +1535,6 @@ class hda_force_enable_audio(FileAction):
             content += '\n# Added by system76-driver.\n'
         else:
             content = '# Added by system76-driver.\n'
-        content += '# Force audio output from DP-1 (physical HDMI 1 port.)\n\n'
-        content += 'xrandr --output DP-1 --set audio on'
+        content += '# Force audio output from DP-1 (physical HDMI 1 port.)\n'
+        content += 'xrandr --output DP-1 --set audio on\n'
         self.atomic_write(content)

--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -1511,9 +1511,9 @@ class i915_initramfs(FileAction):
     def describe(self):
         return _('Add i915 driver to initramfs')
 
-class hda_force_enable_audio(FileAction):
+class displayport1_force_enable_audio(FileAction):
     def describe(self):
-        return _('Force enable audio via HDMI/DP for Intel HDA')
+        return _('Force enable audio output from DP-1 (physical HDMI 1 port.)')
 
     def __init__(self, etcdir='/etc'):
         self.filename = path.join(etcdir, 'xprofile')
@@ -1535,6 +1535,6 @@ class hda_force_enable_audio(FileAction):
             content += '\n# Added by system76-driver.\n'
         else:
             content = '# Added by system76-driver.\n'
-        content += '# Force audio output from DP-1 (physical HDMI 1 port.)\n'
+        content += '# Force enable audio output from DP-1 (physical HDMI 1 port.)\n'
         content += 'xrandr --output DP-1 --set audio on\n'
         self.atomic_write(content)

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -544,7 +544,7 @@ PRODUCTS = {
     'meer6': {
         'name': 'Meerkat',
         'drivers': [
-            actions.hda_force_enable_audio,
+            actions.displayport1_force_enable_audio,
         ],
     },
 

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -544,7 +544,7 @@ PRODUCTS = {
     'meer6': {
         'name': 'Meerkat',
         'drivers': [
-            actions.hda_disable_power_save,
+            actions.hda_force_enable_audio,
         ],
     },
 


### PR DESCRIPTION
The `snd_hda_intel.power_save=0` option doesn't actually get audio working (accessing the systemd-boot menu to add the option manually is what got audio working while testing that option), so this PR removes that action from the meer6.

This PR also adds a new action to run `xrandr --output DP-1 --set audio on` on every graphical login using `/etc/xprofile`.

The meer6 refers to the physical HDMI 1 port as `DP-1`, and the physical HDMI 2 port as `HDMI-1`. The HDMI 2 port appears to have working audio without any tweaking needed, while the HDMI 1 port needs the above command to have working audio on boot. (Other actions that trigger xrandr, such as replugging the display or switching the display input, also get audio working, but the above command should make it happen automatically.)

I will be testing this thoroughly once it's done building, marking this PR as a draft until testing is complete.