### PR TITLE
meer5: Fix audio on revision without headphone jack

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+system76-driver (20.04.34~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.34
+  * meer5: Fix audio on revision without headphone jack
+
+ -- Jacob Kauffmann <jacob@system76.com>  Thu, 10 Jun 2021 06:59:02 -0600
+
 system76-driver (20.04.33) focal; urgency=low
 
   * Apply meer6 audio fix

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.33'
+__version__ = '20.04.34'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -1538,3 +1538,24 @@ class displayport1_force_enable_audio(FileAction):
         content += '# Force enable audio output from DP-1 (physical HDMI 1 port.)\n'
         content += 'xrandr --output DP-1 --set audio on\n'
         self.atomic_write(content)
+
+class meer5_audio_hdajackretask(FileAction):
+    def describe(self):
+        return _('Fix pins for meer5 HDMI/DP audio output.')
+    
+    def __init__(self):
+        self.modprobefile = '/etc/modprobe.d/system76-meer5-audio.conf'
+        self.patchfile = '/lib/firmware/system76-meer5-audio.fw'
+    
+    def get_isneeded(self):
+        if not (os.path.exists(self.modprobefile) and os.path.exists(self.patchfile)):
+            return True
+        else:
+            return False
+    
+    def perform(self):
+        modprobecontent = 'options snd-hda-intel patch=system76-meer5-audio.fw'
+        atomic_write(self.modprobefile, modprobecontent)
+        patchcontent = '[codec]\n0x8086280b 0x80860101 2\n\n'
+        patchcontent += '[pincfg]\n0x05 0x18560070\n0x06 0x18560070\n0x07 0x18560070\n'
+        atomic_write(self.patchfile, patchcontent)

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -539,6 +539,7 @@ PRODUCTS = {
         'name': 'Meerkat',
         'drivers': [
             actions.headset_meer5_fixup,
+            actions.meer5_audio_hdajackretask,
         ],
     },
     'meer6': {


### PR DESCRIPTION
- [X] Fixes audio on new meer5: HDMI and USB-C
- [X] Audio still works on old meer5: front 3.5mm, HDMI, and USB-C