### PR TITLE
Fix 11th gen integrated graphics on thelio-b2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (20.04.37~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.37
+
+ -- leviport <levi@system76.com>  Fri, 25 Jun 2021 10:32:54 -0600
+
 system76-driver (20.04.36) focal; urgency=low
 
   * Thelio-mira-b1: Added quirk for Nvidia GPUs for drivers 460 and 465

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 system76-driver (20.04.37~~alpha) focal; urgency=low
 
   * Daily WIP for 20.04.37
+  * Apply 11th gen Intel fix to thelio-b2
 
  -- leviport <levi@system76.com>  Fri, 25 Jun 2021 10:32:54 -0600
 

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.36'
+__version__ = '20.04.37'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -919,7 +919,9 @@ PRODUCTS = {
     },
     'thelio-b2': {
         'name': 'Thelio',
-        'drivers': [],
+        'drivers': [
+            actions.integrated_11th_gen_intel_fix,
+        ],
     },
     'thelio-r1': {
         'name': 'Thelio',


### PR DESCRIPTION
This applies the same fix that mira-b1 uses