### PR TITLE
FileAction: Create parent directories if necessary

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 system76-driver (20.04.38~~alpha) focal; urgency=low
 
   * Daily WIP for 20.04.38
+  * FileAction: Create parent directories if necessary
 
  -- Jacob Kauffmann <jacob@system76.com>  Thu, 08 Jul 2021 12:28:51 -0600
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (20.04.38~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.38
+
+ -- Jacob Kauffmann <jacob@system76.com>  Thu, 08 Jul 2021 12:28:51 -0600
+
 system76-driver (20.04.37) focal; urgency=low
 
   * Adds an uptime output file for support

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.37'
+__version__ = '20.04.38'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -275,6 +275,7 @@ class FileAction(Action):
 
     def __init__(self, rootdir='/'):
         self.filename = path.join(rootdir, *self.relpath)
+        self.parentdir = path.join(rootdir, *self.relpath[:-1])
 
     def read(self):
         try:
@@ -291,6 +292,8 @@ class FileAction(Action):
         return False
 
     def perform(self):
+        if not os.path.isdir(self.parentdir):
+            os.makedirs(self.parentdir)
         self.atomic_write(self.content, self.mode)
 
 

--- a/system76driver/tests/test_actions.py
+++ b/system76driver/tests/test_actions.py
@@ -300,12 +300,11 @@ class TestFileAction(TestCase):
         inst = Example(rootdir=tmp.dir)
 
         # Missing parentdir:
-        with self.assertRaises(FileNotFoundError) as cm:
-            inst.perform()
-        self.assertEqual(cm.exception.filename, inst.tmp)
+        self.assertIsNone(inst.perform())
+        self._check_file(inst)
 
         # Missing file:
-        tmp.mkdir('some')
+        tmp.remove(inst.filename)
         self.assertIsNone(inst.perform())
         self._check_file(inst)
 
@@ -666,14 +665,11 @@ class Test_wifi_pm_disable(TestCase):
         inst = actions.wifi_pm_disable(rootdir=tmp.dir)
 
         # Missing directories
-        with self.assertRaises(FileNotFoundError) as cm:
-            inst.perform()
-        self.assertEqual(cm.exception.filename, inst.tmp)
+        self.assertIsNone(inst.perform())
+        self._check_file(inst)
 
         # Missing file
-        tmp.mkdir('etc')
-        tmp.mkdir('etc', 'pm')
-        tmp.mkdir('etc', 'pm', 'power.d')
+        tmp.remove(inst.filename)
         self.assertIsNone(inst.perform())
         self._check_file(inst)
 
@@ -761,14 +757,11 @@ class Test_hdmi_hotplug_fix(TestCase):
         inst = actions.hdmi_hotplug_fix(rootdir=tmp.dir)
 
         # Missing directories
-        with self.assertRaises(FileNotFoundError) as cm:
-            inst.perform()
-        self.assertEqual(cm.exception.filename, inst.tmp)
+        self.assertIsNone(inst.perform())
+        self._check_file(inst)
 
         # Missing file
-        tmp.mkdir('etc')
-        tmp.mkdir('etc', 'pm')
-        tmp.mkdir('etc', 'pm', 'power.d')
+        tmp.remove(inst.filename)
         self.assertIsNone(inst.perform())
         self._check_file(inst)
 
@@ -848,13 +841,10 @@ class Test_disable_pm_async(TestCase):
         inst = actions.disable_pm_async(rootdir=tmp.dir)
 
         # Missing directories
-        with self.assertRaises(FileNotFoundError) as cm:
-            inst.perform()
-        self.assertEqual(cm.exception.filename, inst.tmp)
+        self.assertIsNone(inst.perform())
 
         # Missing file
-        tmp.mkdir('etc')
-        tmp.mkdir('etc', 'tmpfiles.d')
+        tmp.remove(inst.filename)
         self.assertIsNone(inst.perform())
         self._check_file(inst)
 
@@ -1620,13 +1610,11 @@ class Test_uvcquirks(TestCase):
         inst = actions.uvcquirks(rootdir=tmp.dir)
 
         # Missing directories
-        with self.assertRaises(FileNotFoundError) as cm:
-            inst.perform()
-        self.assertEqual(cm.exception.filename, inst.tmp)
+        self.assertIsNone(inst.perform())
+        self._check_file(inst)
 
         # Missing file
-        tmp.mkdir('etc')
-        tmp.mkdir('etc', 'modprobe.d')
+        tmp.remove(inst.filename)
         self.assertIsNone(inst.perform())
         self._check_file(inst)
 
@@ -1710,12 +1698,11 @@ class Test_internal_mic_gain(TestCase):
         inst = actions.internal_mic_gain(rootdir=tmp.dir)
 
         # Missing directories
-        with self.assertRaises(FileNotFoundError) as cm:
-            inst.perform()
-        self.assertEqual(cm.exception.filename, inst.tmp)
+        self.assertIsNone(inst.perform())
+        self._check_file(inst)
 
         # Missing file
-        tmp.makedirs('usr', 'share', 'pulseaudio', 'alsa-mixer', 'paths')
+        tmp.remove(inst.filename)
         self.assertIsNone(inst.perform())
         self._check_file(inst)
 


### PR DESCRIPTION
Fixes #207.

Currently, the driver crashes if the parent directory of a config file being written with a FileAction doesn't exist. If this was intentional, then I could see the action just being skipped, but since it actually crashes, it doesn't seem intentional.

Thinking about whether an action should be skipped or performed anyway if the parent directory doesn't already exist, it seems like we'd want config files to be installed anyway, in case the user later installs the component we're trying to configure. In cases where the file is overwritten by the package being installed (such as with the pulseaudio file in #207), the driver will need to be reconfigured after the package is installed either way, so it doesn't really make a difference.

If this seems like a bad idea for any reason, we could instead just skip the action, which would still be better than crashing.