### PR TITLE
lemp9: Add intel_idle.max_cstate=4 kernel parameter to fix freezes 

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (20.04.43~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.43
+
+ -- Jeremy Soller <jeremy@system76.com>  Wed, 29 Sep 2021 08:53:34 -0600
+
 system76-driver (20.04.42) focal; urgency=low
 
   * Add oryp8

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 system76-driver (20.04.43~~alpha) focal; urgency=low
 
   * Daily WIP for 20.04.43
+  * lemp9: Add intel_idle.max_cstate=4 kernel parameter to fix freezes
 
  -- Jeremy Soller <jeremy@system76.com>  Wed, 29 Sep 2021 08:53:34 -0600
 

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.42'
+__version__ = '20.04.43'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -1558,20 +1558,30 @@ class displayport1_force_enable_audio(FileAction):
 class meer5_audio_hdajackretask(FileAction):
     def describe(self):
         return _('Fix pins for meer5 HDMI/DP audio output.')
-    
+
     def __init__(self):
         self.modprobefile = '/etc/modprobe.d/system76-meer5-audio.conf'
         self.patchfile = '/lib/firmware/system76-meer5-audio.fw'
-    
+
     def get_isneeded(self):
         if not (os.path.exists(self.modprobefile) and os.path.exists(self.patchfile)):
             return True
         else:
             return False
-    
+
     def perform(self):
         modprobecontent = 'options snd-hda-intel patch=system76-meer5-audio.fw'
         atomic_write(self.modprobefile, modprobecontent)
         patchcontent = '[codec]\n0x8086280b 0x80860101 2\n\n'
         patchcontent += '[pincfg]\n0x05 0x18560070\n0x06 0x18560070\n0x07 0x18560070\n'
         atomic_write(self.patchfile, patchcontent)
+
+class intel_idle_max_cstate_4(GrubAction):
+    """
+    Add `intel_idle.max_cstate=4` to Linux command line.
+    """
+
+    add = ('intel_idle.max_cstate=4',)
+
+    def describe(self):
+        return _('Fix for freezes on some CML-U processors')

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -453,7 +453,9 @@ PRODUCTS = {
     },
     'lemp9': {
         'name': 'Lemur Pro',
-        'drivers': [],
+        'drivers': [
+            actions.intel_idle_max_cstate_4
+        ],
     },
     'lemp10': {
         'name': 'Lemur Pro',


### PR DESCRIPTION
This should fix https://github.com/pop-os/linux/issues/45