### PR TITLE
lint using flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,11 @@
+[flake8]
+extend-ignore =
+    E101
+    E124
+    E127
+    E128
+    E402
+    E501
+    E722
+    W191
+    W605

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs: 
+ 
+  lint:
+    name: Lint
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set Up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+      - uses: pre-commit/action@v2.0.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+
+    - repo: https://github.com/pycqa/flake8
+      rev: 4.0.1
+      hooks:
+          - id: flake8

--- a/bump-version.py
+++ b/bump-version.py
@@ -31,7 +31,6 @@ import time
 from subprocess import check_call, check_output, call
 
 from system76driver import __version__
-from system76driver.tests.helpers import TempDir
 
 
 DISTROS = ('trusty', 'xenial', 'yakkety', 'zesty', 'artful', 'bionic', 'cosmic', 'disco', 'eoan', 'focal')

--- a/debian/source_system76-driver.py
+++ b/debian/source_system76-driver.py
@@ -11,8 +11,8 @@ LOGS = (
     ('DaemonLog', '/var/log/upstart/system76-driver.log'),
 )
 
+
 def add_info(report):
     report['CrashDB'] = "{'impl': 'launchpad', 'project': 'system76-driver'}"
     for (key, filename) in LOGS:
         attach_file_if_exists(report, filename, key)
-

--- a/make-release.py
+++ b/make-release.py
@@ -45,7 +45,7 @@ assert os.getcwd() == TREE
 CHANGELOG = path.join(TREE, 'debian', 'changelog')
 SETUP = path.join(TREE, 'setup.py')
 INIT = path.join(TREE, 'system76driver', '__init__.py')
-DSC_NAME =     'system76-driver_{}.dsc'.format(__version__)
+DSC_NAME = 'system76-driver_{}.dsc'.format(__version__)
 
 assert path.isfile(CHANGELOG)
 assert path.isfile(SETUP)
@@ -173,6 +173,7 @@ check_call(['dpkg-source', '-b', TREE], cwd=tmp.join('result'))
 check_call(['pbuilder-dist', distro, 'build', tmp.join('result', DSC_NAME)])
 del tmp
 
+
 def abort(msg=None):
     if msg is not None:
         print('\nERROR: ' + msg)
@@ -182,6 +183,7 @@ def abort(msg=None):
     print('Goodbye.')
     status = (0 if msg is None else 2)
     sys.exit(status)
+
 
 # Confirm before we make the commit:
 print('-' * 80)

--- a/system76-driver
+++ b/system76-driver
@@ -65,4 +65,3 @@ log.info('model: %r', args.model)
 
 ui = UI(args.model, product, args)
 ui.run()
-

--- a/system76-driver-cli
+++ b/system76-driver-cli
@@ -74,4 +74,3 @@ try:
 except Exception:
     log.exception('Error running actions:')
     sys.exit(exitcode)
-

--- a/system76-user-daemon
+++ b/system76-user-daemon
@@ -31,11 +31,9 @@ import sys
 import logging
 
 from gi.repository import GLib
-from gi.repository import GObject
 
 import system76driver
 from system76driver import daemon, userdaemon
-from system76driver.daemon import load_json_conf
 
 
 logging.basicConfig(

--- a/system76driver/gtk.py
+++ b/system76driver/gtk.py
@@ -111,7 +111,7 @@ class UI:
     def set_sensitive(self, sensitive):
         for (key, button) in self.buttons.items():
             button.set_sensitive(sensitive and self.enabled[key])
- 
+
     def set_notify(self, icon, text):
         self.notify_text.show()
         self.notify_icon.show()

--- a/system76driver/mockable.py
+++ b/system76driver/mockable.py
@@ -57,4 +57,3 @@ class SubProcess:
             return cls.outputs.pop(0)
         else:
             return subprocess.check_output(cmd, **kw)
-

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -70,7 +70,7 @@ PRODUCTS = {
     'bonx7': {
         'name': 'Bonobo Extreme',
         'drivers': [
-            #actions.plymouth1080,  # Causes problems with nvidia-313-updates
+            # actions.plymouth1080,  # Causes problems with nvidia-313-updates
             actions.wifi_pm_disable,
         ],
     },
@@ -709,7 +709,7 @@ PRODUCTS = {
             actions.i8042_nomux,
         ],
     },
-    #'panv1': {'name': 'Pangolin Value'},  # FIXME: Not in model.py
+    # 'panv1': {'name': 'Pangolin Value'},  # FIXME: Not in model.py
     'panv2': {
         'name': 'Pangolin Value',
         'drivers': [],
@@ -945,7 +945,7 @@ PRODUCTS = {
         'drivers': [],
     },
 
-    #Thelio:
+    # Thelio:
     'thelio-b1': {
         'name': 'Thelio',
         'drivers': [],

--- a/system76driver/tests/__init__.py
+++ b/system76driver/tests/__init__.py
@@ -43,7 +43,7 @@ class TestConstants(TestCase):
         self.assertGreaterEqual(int(year), 13)
         self.assertIn(month, ['04', '10'])
         self.assertEqual(rev, str(int(rev)))
-        self.assertGreaterEqual(int(rev), 0) 
+        self.assertGreaterEqual(int(rev), 0)
 
     def test_VALID_SYS_VENDOR(self):
         self.assertIsInstance(system76driver.VALID_SYS_VENDOR, tuple)
@@ -250,4 +250,3 @@ class TestFunctions(TestCase):
         self.assertIsInstance(value, (type(None), str))
         if isinstance(value, str):
             self.assertEqual(value.strip(), value)
-

--- a/system76driver/tests/helpers.py
+++ b/system76driver/tests/helpers.py
@@ -62,4 +62,3 @@ class TempDir:
 
     def remove(self, *parts):
         os.remove(self.join(*parts))
-

--- a/system76driver/tests/run.py
+++ b/system76driver/tests/run.py
@@ -96,4 +96,3 @@ if __name__ == '__main__':
     args = parser.parse_args()
     if not run_tests(args.skip_gtk):
         raise SystemExit('2')
-

--- a/system76driver/tests/test_actions.py
+++ b/system76driver/tests/test_actions.py
@@ -208,6 +208,7 @@ class NeededAction(actions.Action):
     def get_isneeded(self):
         return True
 
+
 class UnneededAction(actions.Action):
     def get_isneeded(self):
         return False
@@ -1648,7 +1649,14 @@ class Test_internal_mic_gain(TestCase):
         tmp = TempDir()
         inst = actions.internal_mic_gain(rootdir=tmp.dir)
         self.assertEqual(inst.filename,
-            tmp.join('usr', 'share', 'pulseaudio', 'alsa-mixer', 'paths', 'analog-input-internal-mic.conf')
+            tmp.join(
+                'usr',
+                'share',
+                'pulseaudio',
+                'alsa-mixer',
+                'paths',
+                'analog-input-internal-mic.conf'
+            )
         )
 
     def test_read(self):
@@ -1732,6 +1740,7 @@ PATCH_CONTENT = """[codec]
 [verb]
 0x1b 0x707 0x0004
 """
+
 
 class Test_dac_fixup(TestCase):
     def setUp(self):

--- a/system76driver/tests/test_daemon.py
+++ b/system76driver/tests/test_daemon.py
@@ -162,8 +162,8 @@ class TestFunctions(TestCase):
         self.assertEqual(fp.read(), data2)
 
     def test_bit6_is_set(self):
-        self.assertTrue( daemon.bit6_is_set(0b01000000))
-        self.assertTrue( daemon.bit6_is_set(0b11111111))
+        self.assertTrue(daemon.bit6_is_set(0b01000000))
+        self.assertTrue(daemon.bit6_is_set(0b11111111))
         self.assertFalse(daemon.bit6_is_set(0b10111111))
         self.assertFalse(daemon.bit6_is_set(0b00000000))
 
@@ -339,7 +339,7 @@ class TestBrightness(TestCase):
 
         # Existing file:
         self.assertIsNone(inst.write_brightness(76))
-        self.assertEqual(open(inst.brightness_file, 'r').read(), '76')        
+        self.assertEqual(open(inst.brightness_file, 'r').read(), '76')
         self.assertEqual(inst.read_brightness(), 76)
 
     def test_load(self):
@@ -494,4 +494,3 @@ class TestBrightness(TestCase):
         self.assertIsNone(inst.restore())
         self.assertEqual(inst.current, 790)
         self.assertEqual(open(inst.brightness_file, 'rb').read(), b'790')
-

--- a/system76driver/tests/test_model.py
+++ b/system76driver/tests/test_model.py
@@ -121,7 +121,7 @@ class TestConstants(TestCase):
             'serp5': set([
                 ('system-product-name', 'M860TU'),
                 ('system-version', 'serp5'),
-            ]), 
+            ]),
         }
         self.assertEqual(set(multi), set(expected))
         for key in sorted(multi):
@@ -249,4 +249,3 @@ class TestFunctions(TestCase):
             ('check_output', ['dmidecode', '-s', 'system-version'], {}),
         ])
         self.assertEqual(SubProcess.outputs, [])
-

--- a/system76driver/tests/test_util.py
+++ b/system76driver/tests/test_util.py
@@ -52,4 +52,3 @@ class TestFunctions(TestCase):
         tgz = util.create_logs(tmp.dir, func=None)
         self.assertEqual(tgz, tmp.join('system76-logs.tgz'))
         self.assertTrue(path.isfile(tgz))
-

--- a/system76driver/userdaemon.py
+++ b/system76driver/userdaemon.py
@@ -58,6 +58,7 @@ NEEDS_USB_AUDIO = (
     'thelio-mira-b1',
 )
 
+
 class Backlight:
     def __init__(self, model, name, rootdir='/'):
         assert name in ('acpi_video0')
@@ -90,7 +91,7 @@ class Backlight:
             ]
             try:
                 subprocess.check_output(xbrightness_cmd)
-            except:
+            except subprocess.CalledProcessError:
                 time.sleep(1)
 
     def run(self):
@@ -113,6 +114,7 @@ class Backlight:
                 self.set_xbacklight(brightness)
         return True
 
+
 def _run_backlight(model):
     if model not in NEEDS_BACKLIGHT:
         log.info('Backlight hack not needed for %r', model)
@@ -123,11 +125,13 @@ def _run_backlight(model):
     backlight.run()
     return backlight
 
+
 def run_backlight(model):
     try:
         return _run_backlight(model)
     except Exception:
         log.exception('Error calling _run_brightness(%r):', model)
+
 
 class UsbAudio:
     def __init__(self, model, rootdir='/'):
@@ -169,7 +173,7 @@ class UsbAudio:
 
         log.info('USB audio fixup for %r found %r', self.model, self.dir)
 
-        if self.model != "thelio-mira-b1": # do not try to fix s/pdif on mira-b1
+        if self.model != "thelio-mira-b1":  # do not try to fix s/pdif on mira-b1
             subprocess.check_output([
                 "pacmd",
                 "unload-module",
@@ -182,7 +186,7 @@ class UsbAudio:
             "module-alsa-source"
         ])
 
-        if self.model == "thelio-mira-b1": # fix line-in
+        if self.model == "thelio-mira-b1":  # fix line-in
             subprocess.check_output([
                 "pacmd",
                 "load-module",
@@ -191,7 +195,7 @@ class UsbAudio:
                 "source_properties=device.description='Line-in'"
             ])
 
-        else: # do not try to fix s/pdif on mira-b1
+        else:  # do not try to fix s/pdif on mira-b1
             subprocess.check_output([
                 "pacmd",
                 "load-module",
@@ -210,6 +214,7 @@ class UsbAudio:
 
         return False
 
+
 def _run_usb_audio(model):
     if model not in NEEDS_USB_AUDIO:
         log.info('USB audio fixup not needed for %r', model)
@@ -218,6 +223,7 @@ def _run_usb_audio(model):
     usb_audio = UsbAudio(model)
     usb_audio.run()
     return usb_audio
+
 
 def run_usb_audio(model):
     try:

--- a/system76driver/util.py
+++ b/system76driver/util.py
@@ -30,10 +30,12 @@ import subprocess
 
 from .model import determine_model
 
+
 def dump_command(base, name, args):
     fp = open(path.join(base, name), 'xt')
     output = subprocess.run(" ".join(args), capture_output=True, shell=True, text=True)
     fp.write(output.stdout + "\n" + output.stderr)
+
 
 def dump_path(base, name, src):
     if path.exists(src):
@@ -46,6 +48,7 @@ def dump_path(base, name, src):
             shutil.copytree(src, dst)
         else:
             shutil.copy(src, dst)
+
 
 def dump_logs(base):
     fp = open(path.join(base, 'systeminfo.txt'), 'x')
@@ -72,6 +75,7 @@ def dump_logs(base):
     dump_path(base, "apt/term", "/var/log/apt/term.log")
     dump_path(base, "apt/term-rotated", "/var/log/apt/term.log.1.gz")
 
+
 def create_tmp_logs(func=dump_logs):
     tmp = tempfile.mkdtemp(prefix='logs.')
     base = path.join(tmp, 'system76-logs')
@@ -87,6 +91,7 @@ def create_tmp_logs(func=dump_logs):
     ]
     subprocess.run(cmd)
     return (tmp, tgz)
+
 
 def create_logs(homedir, func=dump_logs):
     (tmp, src) = create_tmp_logs(func)


### PR DESCRIPTION
adds a pre-commit hook and corresponding github workflow to lint using `flake8`

i've addressed a couple of lints, but for the most part i've suppressed the errors, so that they can be adopted incrementally. Most of them are related to formatting, and could be resolved in one fell swoop by using a pep8-compliant formatter.