### PR TITLE
Reset network 'links' on resume from sleep

### DIFF
--- a/system76-nm-restart
+++ b/system76-nm-restart
@@ -31,14 +31,16 @@
 set -e
 
 restart_network() {
+    sudo systemctl restart NetworkManager
+    
+    sleep 2
+    
     ip -br link list | awk -F' ' '{if ($2 == "UP") {print $1}}' |
         while IFS="\n" read -r link
         do
             sudo ip link set $link down
             sudo ip link set $link up
         done
-
-    sudo systemctl restart NetworkManager
 }
 
 if [ "$2" = "suspend" ] || [ "$2" = "hybrid-sleep" ]; then

--- a/system76-nm-restart
+++ b/system76-nm-restart
@@ -30,10 +30,21 @@
 
 set -e
 
+restart_network() {
+    ip -br link list | awk -F' ' '{if ($2 == "UP") {print $1}}' |
+        while IFS="\n" read -r link
+        do
+            sudo ip link set $link down
+            sudo ip link set $link up
+        done
+
+    sudo systemctl restart NetworkManager
+}
+
 if [ "$2" = "suspend" ] || [ "$2" = "hybrid-sleep" ]; then
     case "$1" in
         pre) true ;;
-        post) sleep 1 && sudo systemctl restart NetworkManager ;;
+        post) sleep 1 && restart_network ;;
     esac
 fi
 


### PR DESCRIPTION
This resets the network adapters that are up upon resuming from sleep, just before restarting the network manager. For me, this makes them work after resumption. Not too sure why.

I struggled to get this to work with /bin/sh, and wound up spinning up awk to parse the output of 'ip link list' to find the adapters that are up. I'm not sure this is acceptable, but I figured it was better than switching to /bin/bash.

Resolves #226