### PR TITLE
Bluetooth suspend workaround

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 system76-driver (20.04.57~~alpha) focal; urgency=low
 
   * Daily WIP for 20.04.57
+  * Bluetooth suspend workaround
 
  -- Jeremy Soller <jackpot51@gmail.com>  Tue, 21 Jun 2022 12:30:58 -0600
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (20.04.57~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.57
+
+ -- Jeremy Soller <jackpot51@gmail.com>  Tue, 21 Jun 2022 12:30:58 -0600
+
 system76-driver (20.04.56) focal; urgency=low
 
   * Support nvidia-driver-515

--- a/debian/system76-driver.install
+++ b/debian/system76-driver.install
@@ -1,4 +1,5 @@
 com.system76.pkexec.system76-driver.policy usr/share/polkit-1/actions/
+lib
 system76-nm-restart /lib/systemd/system-sleep/
 system76-thunderbolt-reload /lib/systemd/system-sleep/
 system76-apt-preferences /etc/apt/preferences.d/

--- a/lib/systemd/system-sleep/system76-driver_bluetooth-suspend
+++ b/lib/systemd/system-sleep/system76-driver_bluetooth-suspend
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -e
+
+# Do not run if pop-default-settings patch is present
+if [ -x /lib/systemd/system-sleep/pop-default-settings_bluetooth-suspend ]
+then
+    exit 0
+fi
+
+#TODO: save rfkill state?
+case "$2" in
+    suspend | hybrid-sleep)
+        case "$1" in
+            pre)
+				rfkill block bluetooth
+                ;;
+            post)
+				rfkill unblock bluetooth
+                ;;
+        esac
+        ;;
+esac

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.56'
+__version__ = '20.04.57'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)


### PR DESCRIPTION
This script will run if the pop-default-settings is not present to ensure Ubuntu systems also get the bluetooth suspend workaround