### PR TITLE
Display the Manufacturer name ( System76 for now )

### DIFF
--- a/system76driver/data/gtk3.glade
+++ b/system76driver/data/gtk3.glade
@@ -87,6 +87,18 @@ Carl Richell</property>
             <property name="row_spacing">6</property>
             <property name="column_spacing">12</property>
             <child>
+              <object class="GtkLabel" id="sysManufacturer">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">start</property>
+                <property name="label" translatable="yes">{Manufacturer name - you should not see this}</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkLabel" id="sysName">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
@@ -95,7 +107,7 @@ Carl Richell</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">0</property>
+                <property name="top_attach">1</property>
               </packing>
             </child>
             <child>
@@ -107,7 +119,22 @@ Carl Richell</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">1</property>
+                <property name="top_attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="sysManufacturerLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">end</property>
+                <property name="label" translatable="yes">Manufacturer</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
               </packing>
             </child>
             <child>
@@ -122,7 +149,7 @@ Carl Richell</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="top_attach">0</property>
+                <property name="top_attach">1</property>
               </packing>
             </child>
             <child>
@@ -138,7 +165,7 @@ Carl Richell</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="top_attach">1</property>
+                <property name="top_attach">2</property>
               </packing>
             </child>
             <child>
@@ -166,7 +193,7 @@ Carl Richell</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">3</property>
+                <property name="top_attach">4</property>
               </packing>
             </child>
             <child>
@@ -182,7 +209,7 @@ Carl Richell</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">3</property>
               </packing>
             </child>
             <child>
@@ -194,7 +221,7 @@ Carl Richell</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">3</property>
               </packing>
             </child>
           </object>

--- a/system76driver/gtk.py
+++ b/system76driver/gtk.py
@@ -52,6 +52,7 @@ class UI:
         self.notify_icon = self.builder.get_object('notifyImage')
         self.notify_text = self.builder.get_object('notifyLabel')
         self.details = self.builder.get_object('detailsText')
+        self.builder.get_object('sysManufacturer').set_text("System76")
         self.builder.get_object('sysModel').set_text(model)
         self.builder.get_object('ubuntuVersion').set_text(
             '{} {} ({})'.format(*distro.linux_distribution())


### PR DESCRIPTION
As we start to make system76-driver works for other manufacturer, it would be nice to display the manufacturer name 