### PR TITLE
Add action to add NVIDIA DRM driver to initramfs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 system76-driver (20.04.65~~alpha) focal; urgency=low
 
-  * Daily WIP for 20.04.65
+  * Daily WIP for 20.04.66
+  * Add action to add NVIDIA DRM driver to initramfs
+  * Add nvidia-drm to initramfs for oryp6, oryp9, oryp10
 
  -- 13r0ck <bnr@tuta.io>  Wed, 07 Sep 2022 15:46:35 -0600
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (20.04.65~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.65
+
+ -- 13r0ck <bnr@tuta.io>  Wed, 07 Sep 2022 15:46:35 -0600
+
 system76-driver (20.04.64) focal; urgency=low
 
   * Add thelio-mega-r2

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.64'
+__version__ = '20.04.65'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -1585,3 +1585,11 @@ class intel_idle_max_cstate_4(GrubAction):
 
     def describe(self):
         return _('Fix for freezes on some CML-U processors')
+
+class nvidia_drm_initramfs(FileAction):
+    update_initramfs = True
+    relpath = ('usr', 'share', 'initramfs-tools', 'modules.d', 's76-nvidia-initramfs.conf')
+    content = '# Added by system76-driver\nnvidia-drm\n'
+
+    def describe(self):
+        return _('Add nvidia-drm driver to initramfs')

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -674,6 +674,7 @@ PRODUCTS = {
         'drivers': [
             actions.blacklist_nvidia_i2c,
             actions.i915_initramfs,
+            actions.nvidia_drm_initramfs,
         ],
     },
     'oryp7': {
@@ -695,6 +696,7 @@ PRODUCTS = {
         'drivers': [
             actions.blacklist_nvidia_i2c,
             actions.i915_initramfs,
+            actions.nvidia_drm_initramfs,
         ],
     },
     'oryp10': {
@@ -702,6 +704,7 @@ PRODUCTS = {
         'drivers': [
             actions.blacklist_nvidia_i2c,
             actions.i915_initramfs,
+            actions.nvidia_drm_initramfs,
         ],
     },
 

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -1093,7 +1093,9 @@ PRODUCTS = {
     },
     'thelio-mira-b3': {
         'name': 'Thelio Mira',
-        'drivers': [],
+        'drivers': [
+            actions.nvidia_drm_initramfs,
+        ],
     },
     'thelio-mira-r1': {
         'name': 'Thelio Mira',

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -1079,7 +1079,9 @@ PRODUCTS = {
     },
     'thelio-mega-r2': {
         'name': 'Thelio Mega',
-        'drivers': [],
+        'drivers': [
+            actions.nvidia_drm_initramfs,
+        ],
     },
     'thelio-mira-b1': {
         'name': 'Thelio Mira',


### PR DESCRIPTION
Fixes rebooting a system in clamshell mode and having the decryption prompt show up on an external display attached to a dGPU port.

Apply to known affected models:

- oryp6
- oryp9
- oryp10

Ref: https://github.com/pop-os/plymouth-theme/issues/22#issuecomment-1022330320