### PR TITLE
mira-b1: add nvidia drm to initramfs

### DIFF
--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -1089,7 +1089,9 @@ PRODUCTS = {
     },
     'thelio-mira-b3': {
         'name': 'Thelio Mira',
-        'drivers': [],
+        'drivers': [
+            actions.nvidia_drm_initramfs,
+        ],
     },
     'thelio-mira-r1': {
         'name': 'Thelio Mira',


### PR DESCRIPTION
This fixes the plymouth decrypt screen on mira-b3 on the 5.19 kernel