### PR TITLE
Remove nvidia-driver-510 as an optional dependency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (20.04.66~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.66
+
+ -- leviport <levi@system76.com>  Mon, 24 Oct 2022 10:31:52 -0600
+
 system76-driver (20.04.65) focal; urgency=low
 
   * Add thelio-mira-r3

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 system76-driver (20.04.66~~alpha) focal; urgency=low
 
   * Daily WIP for 20.04.66
+  * Remove nvidia-driver-510 dependency option
 
  -- leviport <levi@system76.com>  Mon, 24 Oct 2022 10:31:52 -0600
 

--- a/debian/control
+++ b/debian/control
@@ -54,7 +54,7 @@ Description: Universal driver for System76 computers
 Package: system76-driver-nvidia
 Architecture: all
 Depends: ${misc:Depends},
-    nvidia-driver-515 | nvidia-driver-510 | nvidia-driver-470,
+    nvidia-driver-515 | nvidia-driver-470,
     system76-driver (>= ${binary:Version}),
     ubuntu-drivers-common,
 Recommends: amd-ppt-bin

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.65'
+__version__ = '20.04.66'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)


### PR DESCRIPTION
nvidia-driver-510 doesn't work with Linux 6.0.2. Removing it as an optional dependency probably makes more sense than fixing it at this point, since nvidia-driver-515 has been stable for a while.