### PR TITLE
Add s0ix log file to support log dumps

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (20.04.71~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.71
+
+ -- leviport <levi@system76.com>  Wed, 21 Dec 2022 15:14:39 -0700
+
 system76-driver (20.04.70) focal; urgency=low
 
   * Add thelio-r3

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 system76-driver (20.04.71~~alpha) focal; urgency=low
 
   * Daily WIP for 20.04.71
+  * Add /sys/kernel/debug/pmc_core/slp_s0_residency_usec output to logs
 
  -- leviport <levi@system76.com>  Wed, 21 Dec 2022 15:14:39 -0700
 

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.70'
+__version__ = '20.04.71'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/util.py
+++ b/system76driver/util.py
@@ -79,6 +79,7 @@ def dump_logs(base):
     dump_path(base, "apt/history-rotated.gz", "/var/log/apt/history.log.1.gz")
     dump_path(base, "apt/term", "/var/log/apt/term.log")
     dump_path(base, "apt/term-rotated.gz", "/var/log/apt/term.log.1.gz")
+    dump_path(base, "slp_s0_residency_usec", "/sys/kernel/debug/pmc_core/slp_s0_residency_usec")
 
 def create_tmp_logs(func=dump_logs):
     tmp = tempfile.mkdtemp(prefix='logs.')


### PR DESCRIPTION
This should be useful to the support team while debugging S0ix problems. 

The file it's dumping is `/sys/kernel/debug/pmc_core/slp_s0_residency_usec`. The file starts with `0` in it from boot, and that number increases any time S0ix is successfully reached. The number itself won't be terribly useful (it's something like the number of CPU cycles that it was suspended for, so it might be something like `1808448212`), but it being non-zero means that S0ix is working.

I'm imagining this being useful for the systems that we suspect are having trouble reaching S0ix at all. To use this information effectively, I'm envisioning these logs being generated after the customer has tried suspending and left the machine suspended (or as close as it will get) for about 10 to 15 seconds. Then the support team will be able to tell whether it actually got all the way to S0 residency.

This is just a rough idea, so I'm open to suggestions. I'm sure there are ways to generate a much more useful log file.