### PR TITLE
Blacklist psmouse on TGL and ADL

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (20.04.72~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.72
+
+ -- Tim Crawford <tcrawford@system76.com>  Wed, 18 Jan 2023 11:15:06 -0700
+
 system76-driver (20.04.71) focal; urgency=medium
 
   * Add Pang 12

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 system76-driver (20.04.72~~alpha) focal; urgency=low
 
   * Daily WIP for 20.04.72
+  * Blacklist psmouse on TGL and ADL
 
  -- Tim Crawford <tcrawford@system76.com>  Wed, 18 Jan 2023 11:15:06 -0700
 

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.71'
+__version__ = '20.04.72'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -1617,3 +1617,10 @@ class intel_idle_max_cstate_4(GrubAction):
 
     def describe(self):
         return _('Fix for freezes on some CML-U processors')
+
+class blacklist_psmouse(FileAction):
+    relpath = ('etc', 'modprobe.d', 'blacklist-psmouse.conf')
+    content = 'blacklist psmouse'
+
+    def describe(self):
+        return _('Avoid touchpad issues caused by PS/2 interface')

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -160,11 +160,15 @@ PRODUCTS = {
     },
     'darp7': {
         'name': 'Darter Pro',
-        'drivers': [],
+        'drivers': [
+            actions.blacklist_psmouse,
+        ],
     },
     'darp8': {
         'name': 'Darter Pro',
-        'drivers': [],
+        'drivers': [
+            actions.blacklist_psmouse,
+        ],
     },
 
     # Galago:
@@ -181,14 +185,14 @@ PRODUCTS = {
         'drivers': [
             actions.internal_mic_gain,
             actions.hidpi_scaling,
-	    ],
+        ],
     },
     'galp3': {
         'name': 'Galago Pro',
         'drivers': [
             actions.internal_mic_gain,
             actions.hidpi_scaling,
-	    ],
+        ],
     },
     'galp3-b': {
         'name': 'Galago Pro',
@@ -196,7 +200,7 @@ PRODUCTS = {
             actions.internal_mic_gain,
             actions.energystar_gsettings_override,
             actions.energystar_wakeonlan,
-	    ],
+        ],
     },
     'galp3-c': {
         'name': 'Galago Pro',
@@ -209,12 +213,15 @@ PRODUCTS = {
     'galp5': {
         'name': 'Galago Pro',
         'drivers': [
+            actions.blacklist_psmouse,
             actions.remove_nvidia_dynamic_power_one,
         ],
     },
     'galp6': {
         'name': 'Galago Pro',
-        'drivers': [],
+        'drivers': [
+            actions.blacklist_psmouse,
+        ],
     },
 
     # Gazelle:
@@ -294,13 +301,13 @@ PRODUCTS = {
         'name': 'Gazelle',
         'drivers': [
             actions.internal_mic_gain,
-	],
+        ],
     },
     'gaze13': {
         'name': 'Gazelle',
         'drivers': [
             actions.internal_mic_gain,
-	],
+        ],
     },
     'gaze14': {
         'name': 'Gazelle',
@@ -320,30 +327,35 @@ PRODUCTS = {
         'name': 'Gazelle',
         'drivers': [
             actions.blacklist_nvidia_i2c,
+            actions.blacklist_psmouse,
         ],
     },
     'gaze16-3060': {
         'name': 'Gazelle',
         'drivers': [
             actions.blacklist_nvidia_i2c,
+            actions.blacklist_psmouse,
         ],
     },
     'gaze16-3060-b': {
         'name': 'Gazelle',
         'drivers': [
             actions.blacklist_nvidia_i2c,
+            actions.blacklist_psmouse,
         ],
     },
     'gaze17-3050': {
         'name': 'Gazelle',
         'drivers': [
             actions.blacklist_nvidia_i2c,
+            actions.blacklist_psmouse,
         ],
     },
     'gaze17-3060-b': {
         'name': 'Gazelle',
         'drivers': [
             actions.blacklist_nvidia_i2c,
+            actions.blacklist_psmouse,
         ],
     },
     'gazu1': {
@@ -489,11 +501,15 @@ PRODUCTS = {
     },
     'lemp10': {
         'name': 'Lemur Pro',
-        'drivers': [],
+        'drivers': [
+            actions.blacklist_psmouse,
+        ],
     },
     'lemp11': {
         'name': 'Lemur Pro',
-        'drivers': [],
+        'drivers': [
+            actions.blacklist_psmouse,
+        ],
     },
 
     # Leopard:
@@ -687,6 +703,7 @@ PRODUCTS = {
         'name': 'Oryx Pro',
         'drivers': [
             actions.blacklist_nvidia_i2c,
+            actions.blacklist_psmouse,
             actions.i915_initramfs,
         ],
     },
@@ -695,6 +712,7 @@ PRODUCTS = {
         'drivers': [
             actions.blacklist_nvidia_i2c,
             actions.i915_initramfs,
+            actions.blacklist_psmouse,
         ],
     },
     'oryp10': {
@@ -702,6 +720,7 @@ PRODUCTS = {
         'drivers': [
             actions.blacklist_nvidia_i2c,
             actions.i915_initramfs,
+            actions.blacklist_psmouse,
         ],
     },
 


### PR DESCRIPTION
These models should always use I2C HID, but sometimes try to initialize using the PS/2 interface. Blacklist the module until all issues in firmware can be resolved.

NOTE: This change will need to be reverted when testing firmware changes such as https://github.com/system76/ec/pull/325.