### PR TITLE
Pang12

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,14 +1,9 @@
-system76-driver (20.04.71~~alphaubuntu1) UNRELEASED; urgency=medium
+system76-driver (20.04.71~~alpha) UNRELEASED; urgency=medium
 
   * Daily WIP for 20.04.71
   * Add Pang 12
+  * Add thelio-mira-b4
   * Add `touchpad_use_areas` action
-
- -- system76 <system76@pop-os.localdomain>  Wed, 11 Jan 2023 14:13:14 -0700
-
-system76-driver (20.04.71~~alpha) focal; urgency=low
-
-  * Daily WIP for 20.04.71
 
  -- 13r0ck <brock@szu.email>  Wed, 11 Jan 2023 13:28:14 -0700
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (20.04.71~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.71
+
+ -- 13r0ck <brock@szu.email>  Wed, 11 Jan 2023 13:28:14 -0700
+
 system76-driver (20.04.70) focal; urgency=low
 
   * Add thelio-r3

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+system76-driver (20.04.71~~alphaubuntu1) UNRELEASED; urgency=medium
+
+  * Daily WIP for 20.04.71
+  * Add Pang 12
+  * Add `touchpad_use_areas` action
+
+ -- system76 <system76@pop-os.localdomain>  Wed, 11 Jan 2023 14:13:14 -0700
+
 system76-driver (20.04.71~~alpha) focal; urgency=low
 
   * Daily WIP for 20.04.71

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.70'
+__version__ = '20.04.71'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -1077,6 +1077,38 @@ class energystar_wakeonlan(FileAction):
         return _('Disable Wake-On-LAN on battery power for ENERGY STAR')
 
 
+TOUCHPAD_USE_AREAS_GSETTINGS_OVERRIDE = """[org.gnome.desktop.peripherals.touchpad]
+click-method='areas'
+"""
+
+class touchpad_use_areas(FileAction):
+    relpath = ('usr', 'share', 'glib-2.0', 'schemas',
+        '60_system76-driver-touchpad-use-areas.gschema.override')
+
+    _content = TOUCHPAD_USE_AREAS_GSETTINGS_OVERRIDE
+
+    @property
+    def content(self):
+        return self._content
+
+    def perform(self):
+        self.atomic_write(self.content, self.mode)
+        gsettings_dir = path.join('/', 'usr', 'share', 'glib-2.0', 'schemas')
+        cmd_compile_schemas = ['glib-compile-schemas', gsettings_dir + '/']
+        SubProcess.check_call(cmd_compile_schemas)
+
+    def get_isneeded(self):
+        if self.read() != self.content:
+            return True
+        st = os.stat(self.filename)
+        if stat.S_IMODE(st.st_mode) != self.mode:
+            return True
+        return False
+
+    def describe(self):
+        return _('Apply touchpad click-method default gsettings overrides')
+
+
 LIMIT_TDP_UDEV_RULE = """SUBSYSTEM=="power_supply", ATTR{online}=="0", RUN+="/usr/lib/system76-driver/system76-adjust-tdp --battery"
 SUBSYSTEM=="power_supply", ATTR{online}=="1", RUN+="/usr/lib/system76-driver/system76-adjust-tdp --ac\""""
 

--- a/system76driver/model.py
+++ b/system76driver/model.py
@@ -175,6 +175,7 @@ TABLES = {
         'panp9': 'panp9',
         'pang10': 'pang10',
         'pang11': 'pang11',
+        'pang12': 'pang12',
         'lemu1': 'lemu1',
         'lemu2': 'lemu2',
         'lemu3': 'lemu3',

--- a/system76driver/model.py
+++ b/system76driver/model.py
@@ -257,6 +257,7 @@ TABLES = {
         'thelio-mira-b1': 'thelio-mira-b1',
         'thelio-mira-b2': 'thelio-mira-b2',
         'thelio-mira-b3': 'thelio-mira-b3',
+        'thelio-mira-b4': 'thelio-mira-b4',
         'thelio-mira-r1': 'thelio-mira-r1',
         'thelio-mira-r2': 'thelio-mira-r2',
         'thelio-mira-r3': 'thelio-mira-r3',

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -751,6 +751,12 @@ PRODUCTS = {
             actions.i8042_nomux,
         ],
     },
+    'pang12': {
+        'name': 'Pangolin',
+        'drivers': [
+            actions.touchpad_use_areas,
+        ],
+    },
     #'panv1': {'name': 'Pangolin Value'},  # FIXME: Not in model.py
     'panv2': {
         'name': 'Pangolin Value',

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -1110,6 +1110,10 @@ PRODUCTS = {
         'name': 'Thelio Mira',
         'drivers': [],
     },
+        'thelio-mira-b4': {
+        'name': 'Thelio Mira',
+        'drivers': [],
+    },
     'thelio-mira-r1': {
         'name': 'Thelio Mira',
         'drivers': [],


### PR DESCRIPTION
Adds pang12 as a model and adds a quirk to set the touchpad as split

@leviport this also pulls in https://github.com/pop-os/system76-driver/pull/264