### PR TITLE
Update gaze10/11 for backlight control on kernel 6.2+

### DIFF
--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -490,7 +490,16 @@ class backlight_vendor(GrubAction):
     def describe(self):
         return _('Enable brightness hot keys')
 
+class backlight_native(GrubAction):
+    """
+    Add acpi_backlight=native to GRUB_CMDLINE_LINUX_DEFAULT (for gazp10/11).
+    """
 
+    add = ('acpi_backlight=native',)
+
+    def describe(self):
+        return _('Enable brightness hot keys')
+        
 class remove_backlight_vendor(GrubAction):
     """
     Remove acpi_backlight=vendor to GRUB_CMDLINE_LINUX_DEFAULT (for gazp9).

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -298,14 +298,14 @@ PRODUCTS = {
         'name': 'Gazelle',
         'drivers': [
             actions.internal_mic_gain,
-            actions.backlight_vendor,
+            actions.backlight_native,
         ],
     },
     'gaze11': {
         'name': 'Gazelle',
         'drivers': [
             actions.internal_mic_gain,
-            actions.backlight_vendor,
+            actions.backlight_native,
         ],
     },
     'gaze12': {


### PR DESCRIPTION
Add new system76-driver option to switch to "native" backlight control
Update gaze10/11 to use new option