### PR TITLE
reload atlantic pci bridge to avoid suspend hang

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 system76-driver (20.04.85~~alpha) focal; urgency=low
 
   * Daily WIP for 20.04.85
+  * system76-atlantic-reload: reload atlantic 10G ethernet pci bridge to avoid hangs
 
  -- Jacob Kaulike <jacob.k.tm@gmail.com>  Tue, 02 Jan 2024 07:01:32 -0700
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (20.04.85~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.85
+
+ -- Jacob Kaulike <jacob.k.tm@gmail.com>  Tue, 02 Jan 2024 07:01:32 -0700
+
 system76-driver (20.04.84) focal; urgency=low
 
   * Add thelio-major-r5

--- a/debian/system76-driver.install
+++ b/debian/system76-driver.install
@@ -2,6 +2,7 @@ com.system76.pkexec.system76-driver.policy usr/share/polkit-1/actions/
 lib
 system76-nm-restart /lib/systemd/system-sleep/
 system76-thunderbolt-reload /lib/systemd/system-sleep/
+system76-atlantic-reload /lib/systemd/system-sleep/
 system76-apt-preferences /etc/apt/preferences.d/
 system76-third-party-mirrors.cfg /etc/update-manager/release-upgrades.d/
 system76-driver-pkexec usr/bin/

--- a/system76-atlantic-reload
+++ b/system76-atlantic-reload
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+# system76-driver: Universal driver for System76 computers
+# Copyright (C) 2005-2019 System76, Inc.
+#
+# This file is part of `system76-driver`.
+#
+# `system76-driver` is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# `system76-driver` is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with `system76-driver`; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# This script removes the atlantic 10G ethernet PCI bridge on suspend and
+# rescans it on resume in order to prevent hangs.
+# Bugzilla report: https://bugzilla.kernel.org/show_bug.cgi?id=217260
+
+set -e
+
+case "$(cat /sys/class/dmi/id/product_version)" in
+    thelio-major-r5)
+        case "$2" in
+            suspend | hybrid-sleep)
+                case "$1" in
+                    pre)
+                        echo 1 > '/sys/bus/pci/devices/0000:42:00.0/remove'
+                        ;;
+                    post)
+                        echo 1 > '/sys/devices/pci0000:40/0000:40:03.3/0000:41:00.0/rescan'
+                        ;;
+                esac
+                ;;
+        esac
+        ;;
+esac

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.84'
+__version__ = '20.04.85'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)


### PR DESCRIPTION
removes atlantic 10G ethernet pci bridge pre suspend, then re-scans it back in post suspend to avoid hanging during suspend or on resume.

Workaround for Bugzilla report:  https://bugzilla.kernel.org/show_bug.cgi?id=217260