### PR TITLE
Blacklist psmouse on new models

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (20.04.87~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.87
+
+ -- Tim Crawford <tcrawford@system76.com>  Thu, 07 Mar 2024 12:59:55 -0700
+
 system76-driver (20.04.86) focal; urgency=low
 
   * Add addw4

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,9 @@
 system76-driver (20.04.87~~alpha) focal; urgency=low
 
   * Daily WIP for 20.04.87
+  * addw4: Blacklist psmouse
+  * lemp13: Blacklist psmouse
+  * oryp12: Blacklist psmouse
 
  -- Tim Crawford <tcrawford@system76.com>  Thu, 07 Mar 2024 12:59:55 -0700
 

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.86'
+__version__ = '20.04.87'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -49,6 +49,7 @@ PRODUCTS = {
         'name': 'Adder WS',
         'drivers': [
             actions.blacklist_nvidia_i2c,
+            actions.blacklist_psmouse,
         ],
     },
 
@@ -555,7 +556,9 @@ PRODUCTS = {
     },
     'lemp13': {
         'name': 'Lemur Pro',
-        'drivers': [],
+        'drivers': [
+            actions.blacklist_psmouse,
+        ],
     },
 
     # Leopard:
@@ -790,6 +793,7 @@ PRODUCTS = {
         'drivers': [
             actions.blacklist_nvidia_i2c,
             actions.i915_initramfs,
+            actions.blacklist_psmouse,
         ],
     },
 


### PR DESCRIPTION
Prevents errors like:

```
psmouse serio1: Failed to deactivate mouse on isa0060/serio1: -5
psmouse serio1: Failed to enable mouse on isa0060/serio1
```