### PR TITLE
Fix some invalid string escapes which are now warnings in Python 3.12

### DIFF
--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -43,7 +43,7 @@ CMDLINE_TEMPLATE = 'GRUB_CMDLINE_LINUX_DEFAULT="{}"'
 CMDLINE_CHECK_DEFAULT_RE = re.compile('^GRUB_CMDLINE_LINUX_DEFAULT')
 CMDLINE_ADD_DEFAULT_RE = re.compile('^GRUB_CMDLINE_LINUX="(.*)"$')
 
-LSPCI_RE = re.compile('^(.+) \[(.+)\]$')
+LSPCI_RE = re.compile(r'^(.+) \[(.+)\]$')
 
 WIFI_PM_DISABLE = """#!/bin/sh
 # Installed by system76-driver
@@ -1129,7 +1129,7 @@ action=/etc/acpi/system76-brightness-tdp.sh"""
 LIMIT_TDP_ACPI_ACTION = """#!/bin/sh
 /usr/lib/system76-driver/system76-adjust-tdp"""
 
-LIMIT_TDP_SCRIPT = """#!/bin/sh
+LIMIT_TDP_SCRIPT = r"""#!/bin/sh
 
 adjust_tdp ()
 {


### PR DESCRIPTION
Hey,

Debian testing/sid and Gentoo now have Python 3.12 by default.  One of the changes in 3.12 is that invalid string escape sequences now produce a SyntaxWarning (and in some future Python this will become an error).  There are some invalid escapes in actions.py that cause the user-visible messages below.  This PR fixes these two.  I don't see warnings for any others in my build log.

    Setting up system76-driver (20.04.91-0kh13.1) ...
    WARNING invalid sys_vendor: 'Dell Inc.'
    WARNING invalid product_version: None
    /usr/lib/python3/dist-packages/system76driver/actions.py:46: SyntaxWarning: invalid escape sequence '\['
    LSPCI_RE = re.compile('^(.+) \[(.+)\]$')
    /usr/lib/python3/dist-packages/system76driver/actions.py:1132: SyntaxWarning: invalid escape sequence '\:'
    LIMIT_TDP_SCRIPT = """#!/bin/sh

Thanks.