### PR TITLE
Remove psmouse blacklist on RPL, MTL

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 system76-driver (20.04.107~~alpha) focal; urgency=low
 
   * Daily WIP for 20.04.107
+  * rpl,mtl: Remove psmouse blacklist
 
  -- Tim Crawford <tcrawford@system76.com>  Thu, 19 Dec 2024 07:35:39 -0700
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (20.04.107~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.107
+
+ -- Tim Crawford <tcrawford@system76.com>  Thu, 19 Dec 2024 07:35:39 -0700
+
 system76-driver (20.04.106) focal; urgency=low
 
   * thelio-astra-a1: Manual configuration of BMC USB ethernet

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.106'
+__version__ = '20.04.107'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -1626,6 +1626,21 @@ class blacklist_psmouse(FileAction):
     def describe(self):
         return _('Avoid touchpad issues caused by PS/2 interface')
 
+class remove_blacklist_psmouse(FileAction):
+    relpath = ('etc', 'modprobe.d', 'blacklist-psmouse.conf')
+
+    def describe(self):
+        return _('Remove PS/2 blacklist for models with touchpad fix')
+
+    def get_isneeded(self):
+        return os.path.exists(self.filename)
+
+    def perform(self):
+        try:
+            os.remove(self.filename)
+        except:
+            pass
+
 class mask_suspend(Action):
     target_names = ['hibernate.target', 'hybrid-sleep.target', 'sleep.target', 'suspend.target']
 

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -42,14 +42,14 @@ PRODUCTS = {
         'name': 'Adder WS',
         'drivers': [
             actions.blacklist_nvidia_i2c,
-            actions.blacklist_psmouse,
+            actions.remove_blacklist_psmouse,
         ],
     },
     'addw4': {
         'name': 'Adder WS',
         'drivers': [
             actions.blacklist_nvidia_i2c,
-            actions.blacklist_psmouse,
+            actions.remove_blacklist_psmouse,
         ],
     },
 
@@ -195,19 +195,19 @@ PRODUCTS = {
     'darp9': {
         'name': 'Darter Pro',
         'drivers': [
-            actions.blacklist_psmouse,
+            actions.remove_blacklist_psmouse,
         ],
     },
     'darp10': {
         'name': 'Darter Pro',
         'drivers': [
-            actions.blacklist_psmouse,
+            actions.remove_blacklist_psmouse,
         ],
     },
     'darp10-b': {
         'name': 'Darter Pro',
         'drivers': [
-            actions.blacklist_psmouse,
+            actions.remove_blacklist_psmouse,
         ],
     },
 
@@ -266,7 +266,7 @@ PRODUCTS = {
     'galp7': {
         'name': 'Galago Pro',
         'drivers': [
-            actions.blacklist_psmouse,
+            actions.remove_blacklist_psmouse,
         ],
     },
 
@@ -408,7 +408,7 @@ PRODUCTS = {
         'name': 'Gazelle',
         'drivers': [
             actions.blacklist_nvidia_i2c,
-            actions.blacklist_psmouse,
+            actions.remove_blacklist_psmouse,
         ],
     },
     'gazu1': {
@@ -567,19 +567,19 @@ PRODUCTS = {
     'lemp12': {
         'name': 'Lemur Pro',
         'drivers': [
-            actions.blacklist_psmouse,
+            actions.remove_blacklist_psmouse,
         ],
     },
     'lemp13': {
         'name': 'Lemur Pro',
         'drivers': [
-            actions.blacklist_psmouse,
+            actions.remove_blacklist_psmouse,
         ],
     },
     'lemp13-b': {
         'name': 'Lemur Pro',
         'drivers': [
-            actions.blacklist_psmouse,
+            actions.remove_blacklist_psmouse,
         ],
     },
 
@@ -815,7 +815,7 @@ PRODUCTS = {
         'drivers': [
             actions.blacklist_nvidia_i2c,
             actions.i915_initramfs,
-            actions.blacklist_psmouse,
+            actions.remove_blacklist_psmouse,
         ],
     },
     'oryp12': {
@@ -823,7 +823,7 @@ PRODUCTS = {
         'drivers': [
             actions.blacklist_nvidia_i2c,
             actions.i915_initramfs,
-            actions.blacklist_psmouse,
+            actions.remove_blacklist_psmouse,
         ],
     },
 
@@ -1101,7 +1101,7 @@ PRODUCTS = {
         'drivers': [
             actions.blacklist_nvidia_i2c,
             actions.i915_initramfs,
-            actions.blacklist_psmouse,
+            actions.remove_blacklist_psmouse,
         ],
     },
 


### PR DESCRIPTION
Remove psmouse blacklist on RPL, MTL

PS/2 touchpad is fixed in System76 EC with the following commits:

- system76/ec@d88a175e23f3 Clear PS/2 touchpad status when waiting for write to finish
- system76/ec@5b0766a2099f USe debounce bit and do not use interrupts for touchpad

All systems running system76/firmware-open@9e418a22fffe (2024-06-26) or newer include these changes.

Ref: https://github.com/system76/ec/pull/464
Ref: https://github.com/system76/firmware-open/pull/558

Required firmware releases:

- [x] [addw3](https://github.com/system76/firmware/pull/689)
- [x] [addw4](https://github.com/system76/firmware/pull/690)
- [x] [darp9](https://github.com/system76/firmware/pull/672)
- [x] [darp10](https://github.com/system76/firmware/pull/701)
- [x] [darp10-b](https://github.com/system76/firmware/pull/701)
- [x] [galp7](https://github.com/system76/firmware/pull/671)
- [x] [gaze18](https://github.com/system76/firmware/pull/673)
- [x] [lemp12](https://github.com/system76/firmware/pull/669)
- [x] [lemp13](https://github.com/system76/firmware/pull/691)
- [x] [lemp13-b](https://github.com/system76/firmware/pull/680)
- [x] [oryp11](https://github.com/system76/firmware/pull/692)
- [x] [oryp12](https://github.com/system76/firmware/pull/693)
- [x] [serw13](https://github.com/system76/firmware/pull/670)
