### PR TITLE
Bump nvidia driver to 550

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 system76-driver (20.04.99~~alpha) focal; urgency=low
 
   * Daily WIP for 20.04.99
+  * Bump nvidia-driver to 550
 
  -- Jeremy Soller <jackpot51@gmail.com>  Wed, 23 Oct 2024 08:41:56 -0600
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (20.04.99~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.99
+
+ -- Jeremy Soller <jackpot51@gmail.com>  Wed, 23 Oct 2024 08:41:56 -0600
+
 system76-driver (20.04.98) focal; urgency=low
 
   * Depend on virtual package for system76-power applet

--- a/debian/control
+++ b/debian/control
@@ -54,7 +54,7 @@ Description: Universal driver for System76 computers
 Package: system76-driver-nvidia
 Architecture: amd64 arm64
 Depends: ${misc:Depends},
-    nvidia-driver-525 | nvidia-driver-515 | nvidia-driver-470,
+    nvidia-driver-550 | nvidia-driver-470,
     system76-driver (>= ${binary:Version}),
     ubuntu-drivers-common,
 Recommends: amd-ppt-bin [amd64]

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.98'
+__version__ = '20.04.99'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)


### PR DESCRIPTION
On x86 systems, nvidia-driver-550 is provided as a transitional package to nvidia-driver-560.
On ARM systems, nvidia-driver-550 is the latest Ubuntu version available.
This ensures both architectures get the latest NVIDIA driver.