### PR TITLE
Add kernel revision nobuild

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (20.04.108~~alpha) focal; urgency=low
+
+  * Daily WIP for 20.04.108
+
+ -- Aaron Honeycutt <aaronhoneycutt@proton.me>  Thu, 23 Jan 2025 11:49:21 -0700
+
 system76-driver (20.04.107) focal; urgency=low
 
   * rpl,mtl: Remove psmouse blacklist

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 system76-driver (20.04.108~~alpha) focal; urgency=low
 
   * Daily WIP for 20.04.108
+  * Adds kernel revision to systeminfo.txt file
 
  -- Aaron Honeycutt <aaronhoneycutt@proton.me>  Thu, 23 Jan 2025 11:49:21 -0700
 

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '20.04.107'
+__version__ = '20.04.108'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/util.py
+++ b/system76driver/util.py
@@ -52,6 +52,7 @@ def dump_logs(base):
     fp.write('System76 Model: {}\n'.format(determine_model_new()))
     fp.write('OS Version: {}\n'.format(distro.name(pretty=True)))
     fp.write('Kernel Version: {}\n'.format(os.uname().release))
+    fp.write('Kernel Revision: {}\n'.format(os.uname().version))
 
     dump_command(base, "boot-process-times", ["systemd-analyze", "blame"])
     dump_command(base, "free-disk-space", ["df", "-h"])


### PR DESCRIPTION
This adds an additional line for systeminfo.txt which looks like this in the Pop Support Pane:

Kernel Revision: #202405300957~1736980680~22.04~44ea8a9

now the systeminfo.txt from the system76-driver will include it as well, this is useful when we bump the kernel to include a fix like the pang15 but it does not change from the current version such as 6.9.3 so we can see by the hash if it included the fix. 