### PR TITLE
addw3,addw4: Re-add psmouse blacklist

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (24.04.9~~alpha) noble; urgency=low
+
+  * Daily WIP for 24.04.9
+
+ -- Tim Crawford <tcrawford@system76.com>  Thu, 17 Jul 2025 13:31:57 -0600
+
 system76-driver (24.04.8) noble; urgency=low
 
   * Add gaze20

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 system76-driver (24.04.9~~alpha) noble; urgency=low
 
   * Daily WIP for 24.04.9
+  * addw3: Re-add psmouse blacklist
+  * addw4: Re-add psmouse blacklist
 
  -- Tim Crawford <tcrawford@system76.com>  Thu, 17 Jul 2025 13:31:57 -0600
 

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '24.04.8'
+__version__ = '24.04.9'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -42,14 +42,14 @@ PRODUCTS = {
         'name': 'Adder WS',
         'drivers': [
             actions.blacklist_nvidia_i2c,
-            actions.remove_blacklist_psmouse,
+            actions.blacklist_psmouse,
         ],
     },
     'addw4': {
         'name': 'Adder WS',
         'drivers': [
             actions.blacklist_nvidia_i2c,
-            actions.remove_blacklist_psmouse,
+            actions.blacklist_psmouse,
         ],
     },
     'addw5': {


### PR DESCRIPTION
PS/2 interface seems to still be problematic. Every boot/resume fails to
initialize the device with:

    psmouse serio1: Failed to deactivate mouse on isa0060/serio1: -5
    psmouse serio1: Failed to enable mouse on isa0060/serio1

Would be good to check if other models are doing this, or if it's just addw4.