### PR TITLE
Update serw12 xprofile to only run on NVIDIA < 500

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (24.04.14) noble; urgency=low
+
+  * Update serw12 xprofile to only run on NVIDIA < 500
+
+ -- Jacob Kauffmann <jacob@system76.com>  Thu, 23 Oct 2025 15:07:49 -0600
+
 system76-driver (24.04.13) noble; urgency=low
 
   * Set NVreg_DynamicPowerManagement on affected models

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '24.04.13'
+__version__ = '24.04.14'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)


### PR DESCRIPTION
The `ForceFullCompositionPipeline` isn't needed on NVIDIA driver versions 500+. Removing it gets rid of a flicker during login and speeds up login by a little over 2 seconds.

However, we still offer `nvidia-driver-470`, and if I install that, then I still get stuttering/lagging (reproducible typing sentences in LibreOffice Writer).

This change to the script will check the driver version and only apply the settings change if it's less than 500.

## Installation:

- [X] Tested that upgrading while the old script file was present (e.g. normal upgrade) results in it being replaced with the new script file.
- [X] Tested that upgrading while the script file's not present (e.g. new installation) results in the new script file being added.
- [X] Tested that upgrading with the old script file having been modified works as expected.
    - [X] If the entire script was still intact somewhere within xprofile (e.g. lines added before or after), replace it.
    - [X] If part of the old script was changed (e.g. modification in the middle of it), don't touch xprofile.

## Function:

- [X] Tested that with driver 470, the option's applied.
- [X] Tested that with driver 580, the option's not applied.
- [X] Tested that I can log in without the NVIDIA driver installed.
    - This script still results in an error dialog being shown if the NVIDIA driver's not installed, but that was already the case before.