### PR TITLE
Disable GSP firmware on addw4

### DIFF
--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -1715,6 +1715,17 @@ class bmc_usb_ethernet(FileAction):
     def describe(self):
         return _('Manual configuration of BMC USB ethernet')
 
+class nvidia_disable_gsp_firmware(FileAction):
+    """
+    Disable GSP firmware on models that conflict with it.
+    This action will not affect installations using nvidia-open.
+    """
+    relpath = ('etc', 'modprobe.d', 'nvidia_disable_gsp_firmware.conf')
+    content = 'options nvidia NVreg_EnableGpuFirmware=0'
+
+    def describe(self):
+        return _("Disable GSP firmware on models that conflict with it")
+
 class nvidia_coarse_power_management(FileAction):
     relpath = ('etc', 'modprobe.d', 'nvidia-runtimepm.conf')
     content = 'options nvidia NVreg_DynamicPowerManagement=0x01'

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -51,6 +51,7 @@ PRODUCTS = {
             actions.blacklist_nvidia_i2c,
             actions.blacklist_psmouse,
             actions.nvidia_coarse_power_management,
+            actions.nvidia_disable_gsp_firmware,
         ],
     },
     'addw5': {


### PR DESCRIPTION
The use of GSP firmware on the addw4 can cause a crash after waking from suspend that requires a hard reboot.

I discovered that it can be fixed by disabling the GSP firmware in the Nvidia driver. Of course, this only works with the proprietary drivers, but it's pretty much the currently required driver for proper functionality. nvidia-open has some quirks, such as DirectX 12/vkd3d-proton titles not working.

I think this patch will can serve as a good workaround while a proper fix for the addw4 is being investigated.