### PR TITLE
feat: support nvidia-driver-595

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -56,9 +56,9 @@ Description: Universal driver for System76 computers
 Package: system76-driver-nvidia
 Architecture: amd64 arm64
 Depends: ${misc:Depends},
-    nvidia-driver-580-open | nvidia-driver-580 | nvidia-driver-570-open |
-    nvidia-driver-570 | nvidia-driver-550 | nvidia-driver-470,
-    system76-driver (>= ${binary:Version}),
+    nvidia-driver-595 | nvidia-driver-580-open | nvidia-driver-580 |
+    nvidia-driver-570-open | nvidia-driver-570 | nvidia-driver-550 |
+    nvidia-driver-470, system76-driver (>= ${binary:Version}),
     ubuntu-drivers-common,
 Recommends: amd-ppt-bin [amd64]
 Description: Latest nvidia driver for System76 computers


### PR DESCRIPTION
Only requires `nvidia-driver-595` since the open driver is now the only driver