### PR TITLE
Prefer NVIDIA 580 until 595 issues are resolved

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (24.04.18) noble; urgency=medium
+
+  * Prefer NVIDIA 580 until 595 issues are resolved
+
+ -- Jeremy Soller <jeremy@system76.com>  Tue, 19 May 2026 20:02:57 -0600
+
 system76-driver (24.04.17) noble; urgency=medium
 
   * Install new System76 hosted repository for Ubuntu

--- a/debian/control
+++ b/debian/control
@@ -57,9 +57,12 @@ Description: Universal driver for System76 computers
 Package: system76-driver-nvidia
 Architecture: amd64 arm64
 Depends: ${misc:Depends},
-    nvidia-driver-595 | nvidia-driver-580-open | nvidia-driver-580 |
-    nvidia-driver-570-open | nvidia-driver-570 | nvidia-driver-550 |
-    nvidia-driver-470, system76-driver (>= ${binary:Version}),
+    nvidia-driver-580-open | nvidia-driver-580 |
+    nvidia-driver-595 |
+    nvidia-driver-570-open | nvidia-driver-570 |
+    nvidia-driver-550 |
+    nvidia-driver-470,
+    system76-driver (>= ${binary:Version}),
     ubuntu-drivers-common,
 Recommends: amd-ppt-bin [amd64]
 Description: Latest nvidia driver for System76 computers

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '24.04.17'
+__version__ = '24.04.18'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)


### PR DESCRIPTION
595 currently has suspend issues. If fixed later, it can be made the preferred driver.