### PR TITLE
Add force removal of mediatek wifi on suspend for pang12-15, panp16

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (24.04.20) noble; urgency=medium
+
+  * Bump version to 24.04.20
+
+ -- Jeremy Soller <jeremy@system76.com>  Mon, 01 Jun 2026 10:00:00 -0600
+
 system76-driver (24.04.18) noble; urgency=medium
 
   * Add wifi_reload action to remove MediaTek MT7921/MT7922 WiFi PCI device on suspend and rescan on resume for pang12-pang15 and panp16

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-system76-driver (24.04.21) noble; urgency=medium
+system76-driver (24.04.20) noble; urgency=medium
 
   * Add wifi_reload action to remove MediaTek MT7921/MT7922 WiFi PCI device on suspend and rescan on resume for pang12-pang15 and panp16
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-driver (24.04.18) noble; urgency=medium
+
+  * Add wifi_reload action to remove MediaTek MT7921/MT7922 WiFi PCI device on suspend and rescan on resume for pang12-pang15 and panp16
+
+ -- Thomas Zimmerman <thomas@system76.com>  Tue, 19 May 2026 14:59:48 -0600
+
 system76-driver (24.04.17) noble; urgency=medium
 
   * Install new System76 hosted repository for Ubuntu

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,12 +4,6 @@ system76-driver (24.04.21) noble; urgency=medium
 
  -- Thomas Zimmerman <thomas@system76.com>  Tue, 9 Jun 2026 14:21:48 -0600
 
-system76-driver (24.04.20) noble; urgency=medium
-
-  * Bump version to 24.04.20
-
- -- Jeremy Soller <jeremy@system76.com>  Mon, 01 Jun 2026 10:00:00 -0600
-
 system76-driver (24.04.19) noble; urgency=medium
 
   * Add thelio-mira-r5

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '24.04.21'
+__version__ = '24.04.20'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/__init__.py
+++ b/system76driver/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '24.04.17'
+__version__ = '24.04.20'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -63,6 +63,42 @@ DISABLE_PM_ASYNC = """# /etc/tmpfiles.d/system76-disable-pm_async.conf
 w /sys/power/pm_async - - - - 0
 """
 
+WIFI_RELOAD = """#!/bin/sh
+
+# Installed by system76-driver
+# Removes the MediaTek MT7921/MT7922 wireless adapter on suspend and
+# rescans the PCI bus on resume. The MT7922 firmware/driver can lose
+# background scan and connection state after suspend, resulting in
+# degraded WiFi performance or complete failure to reconnect. Forcibly
+# removing the PCI device on suspend and rescanning on resume ensures
+# the adapter is fully re-initialized.
+
+set -e
+
+mediatek_vendor="0x14c3"
+
+case "$2" in
+    suspend | hybrid-sleep)
+        case "$1" in
+            pre)
+                for dev in /sys/bus/pci/devices/*; do
+                    vendor=$(cat "$dev/vendor" 2>/dev/null || true)
+                    if [ "$vendor" = "$mediatek_vendor" ]; then
+                        device=$(cat "$dev/device" 2>/dev/null || true)
+                        if [ "$device" = "0x7961" ] || [ "$device" = "0x0616" ]; then
+                            echo 1 > "$dev/remove" 2>/dev/null || true
+                        fi
+                    fi
+                done
+                ;;
+            post)
+                echo 1 > /sys/bus/pci/rescan 2>/dev/null || true
+                ;;
+        esac
+        ;;
+esac
+"""
+
 
 def random_id(numbytes=15):
     return b32encode(os.urandom(numbytes)).decode('utf-8')
@@ -1744,3 +1780,11 @@ class remove_nvidia_coarse_power_management(FileAction):
             os.remove(self.filename)
         except:
             pass
+
+class wifi_reload(FileAction):
+    relpath = ('lib', 'systemd', 'system-sleep', 'system76-wifi-reload')
+    content = WIFI_RELOAD
+    mode = 0o755
+
+    def describe(self):
+        return _('Remove MediaTek WiFi PCI device on suspend and rescan on resume')

--- a/system76driver/products.py
+++ b/system76driver/products.py
@@ -920,30 +920,35 @@ PRODUCTS = {
         'name': 'Pangolin',
         'drivers': [
             actions.touchpad_use_areas,
+            actions.wifi_reload,
         ],
     },
     'pang13': {
         'name': 'Pangolin',
         'drivers': [
             actions.touchpad_use_areas,
+            actions.wifi_reload,
         ],
     },
     'pang14': {
         'name': 'Pangolin',
         'drivers': [
             actions.touchpad_use_areas,
+            actions.wifi_reload,
         ],
     },
     'pang15': {
         'name': 'Pangolin',
         'drivers': [
             actions.touchpad_use_areas,
+            actions.wifi_reload,
         ],
     },
     'panp16': {
         'name': 'Pangolin Pro',
         'drivers': [
             actions.touchpad_use_areas,
+            actions.wifi_reload,
         ],
     },
     #'panv1': {'name': 'Pangolin Value'},  # FIXME: Not in model.py


### PR DESCRIPTION
I've had rare reports that wifi on pang12-15 is flaky after suspend/resume. Panp16 has even more reports. In testing, if connected to a access point that is not there on resume, background scan for other access points stops most of the time. 

Closes https://github.com/system76/testing/issues/515

Tested on pang14 and panp16

opencode (LLM) was used to help create this PR