### PR TITLE
Set NVIDIA 595 as the default driver

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -57,8 +57,8 @@ Description: Universal driver for System76 computers
 Package: system76-driver-nvidia
 Architecture: amd64 arm64
 Depends: ${misc:Depends},
-    nvidia-driver-580-open | nvidia-driver-580 |
     nvidia-driver-595 |
+    nvidia-driver-580-open | nvidia-driver-580 |
     nvidia-driver-570-open | nvidia-driver-570 |
     nvidia-driver-550 |
     nvidia-driver-470,


### PR DESCRIPTION
Latest driver release fixes suspend issues with Linux 7.0 so it should be preferred over 580-open now.